### PR TITLE
fix static site exports

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -14,17 +14,50 @@ interface BlogPostPageProps {
   };
 }
 
-export function generateStaticParams() {
+// For Static Export (output: 'export'), dynamic routes must:
+// - enumerate all params to pre-render, and
+// - disable fallback (no runtime generation).
+export const dynamicParams = false;
+
+export const generateStaticParams = async () => {
   const slugs = getAllPostSlugs();
+  // Generate a single placeholder page so the export build won't fail
+  // even when there are zero blog posts (no slugs to pre-render).
+  if (slugs.length === 0) {
+    return [{ slug: 'coming-soon' }];
+  }
   return slugs.map((slug) => ({
     slug,
   }));
-}
+};
 
 export default function BlogPostPage({ params }: BlogPostPageProps) {
   const post = getPostBySlug(params.slug);
 
   if (!post) {
+    if (params.slug === 'coming-soon') {
+      return (
+        <Container maxWidth="md" sx={{ mt: 4 }}>
+          <Header />
+          <Box sx={{ my: 4 }}>
+            <Link
+              component={NextLink}
+              href="/blog"
+              underline="hover"
+              sx={{ mb: 2, display: 'inline-block' }}
+            >
+              ← Back to Blog
+            </Link>
+            <Typography variant="h4" component="h1" gutterBottom>
+              Coming soon
+            </Typography>
+            <Typography variant="body1" color="text.secondary">
+              Blog posts are coming soon.
+            </Typography>
+          </Box>
+        </Container>
+      );
+    }
     notFound();
   }
 

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -8,6 +8,8 @@ import NextLink from 'next/link';
 import { notFound } from 'next/navigation';
 import rehypeHighlight from 'rehype-highlight';
 
+const PLACEHOLDER_SLUG = '__blog-placeholder__';
+
 interface BlogPostPageProps {
   params: {
     slug: string;
@@ -24,7 +26,7 @@ export const generateStaticParams = async () => {
   // Generate a single placeholder page so the export build won't fail
   // even when there are zero blog posts (no slugs to pre-render).
   if (slugs.length === 0) {
-    return [{ slug: 'coming-soon' }];
+    return [{ slug: PLACEHOLDER_SLUG }];
   }
   return slugs.map((slug) => ({
     slug,
@@ -32,10 +34,14 @@ export const generateStaticParams = async () => {
 };
 
 export default function BlogPostPage({ params }: BlogPostPageProps) {
+  const hasAnyPosts = getAllPostSlugs().length > 0;
   const post = getPostBySlug(params.slug);
 
   if (!post) {
-    if (params.slug === 'coming-soon') {
+    // Only show the placeholder page when there are zero posts.
+    // This prevents conflicts if someone ever creates a real post whose slug
+    // happens to match the placeholder.
+    if (!hasAnyPosts && params.slug === PLACEHOLDER_SLUG) {
       return (
         <Container maxWidth="md" sx={{ mt: 4 }}>
           <Header />


### PR DESCRIPTION
This pull request updates the blog post page logic to better support static site exports, especially when there are no blog posts available. The main improvements ensure that the static export build does not fail if there are zero blog posts, and provides a user-friendly placeholder page in that scenario.

**Static export improvements:**

* Sets `dynamicParams` to `false` to disable runtime dynamic route generation, ensuring all possible blog post slugs are enumerated at build time. ([src/app/blog/[slug]/page.tsxL17-R60](diffhunk://#diff-7982871d233df68cc6cee151ccebf838f98bc4923f8a050a9cf2217e6b3a27f7L17-R60))
* Updates `generateStaticParams` to return a placeholder `{ slug: 'coming-soon' }` if no blog posts exist, preventing build failures during static export. ([src/app/blog/[slug]/page.tsxL17-R60](diffhunk://#diff-7982871d233df68cc6cee151ccebf838f98bc4923f8a050a9cf2217e6b3a27f7L17-R60))

**User experience enhancements:**

* Adds logic to display a "Coming soon" placeholder page when the user navigates to `/blog/coming-soon`, informing visitors that blog posts will be available in the future. ([src/app/blog/[slug]/page.tsxL17-R60](diffhunk://#diff-7982871d233df68cc6cee151ccebf838f98bc4923f8a050a9cf2217e6b3a27f7L17-R60))