### PR TITLE
Add external blog posts support for SpeakerDeck and Zenn

### DIFF
--- a/content/blog/20250528_cursor-team-introduction.mdx
+++ b/content/blog/20250528_cursor-team-introduction.mdx
@@ -1,0 +1,8 @@
+---
+title: "AIコードエディタは開発を変えるか〜Cursorをチームに導入して1ヶ月経った本音"
+description: "Cursorをチームに導入して1ヶ月経過した実体験を共有するSpeakerDeck発表資料です。"
+date: "2025-05-28"
+category: "speakerdeck"
+tags: ["SpeakerDeck", "Cursor", "AI", "チーム開発"]
+externalUrl: "https://speakerdeck.com/ota1022/aikodoedeitahakai-fa-wobian-eruka-cursorwotimunidao-ru-site1keyue-jing-tutaben-yin"
+---

--- a/content/blog/20250821_docker-to-ecs.mdx
+++ b/content/blog/20250821_docker-to-ecs.mdx
@@ -1,0 +1,8 @@
+---
+title: "DockerからECSへ〜AWSの海に出る前に知っておきたいこと"
+description: "DockerからAWS ECSへの移行について、事前に知っておくべきポイントをまとめたSpeakerDeck発表資料です。"
+date: "2025-08-21"
+category: "speakerdeck"
+tags: ["SpeakerDeck", "Docker", "AWS", "ECS"]
+externalUrl: "https://speakerdeck.com/ota1022/dockerkaraecshe-awsnohai-nichu-ruqian-nizhi-tuteokitaikoto"
+---

--- a/content/blog/20250925_github-actions-aws-oidc.mdx
+++ b/content/blog/20250925_github-actions-aws-oidc.mdx
@@ -1,0 +1,8 @@
+---
+title: "GitHub Actions x AWS OIDC連携の仕組みと警戒を理解する"
+description: "GitHub ActionsとAWS間のOIDC連携について、仕組みと注意点を解説したSpeakerDeck発表資料です。"
+date: "2025-09-25"
+category: "speakerdeck"
+tags: ["SpeakerDeck", "GitHub Actions", "AWS", "OIDC", "CI/CD"]
+externalUrl: "https://speakerdeck.com/ota1022/github-actions-x-aws-oidclian-xi-noshi-zu-mitojing-wei-woli-jie-suru"
+---

--- a/content/blog/20251030_trayce-raycast-extension.mdx
+++ b/content/blog/20251030_trayce-raycast-extension.mdx
@@ -1,0 +1,8 @@
+---
+title: "Trayce - A Raycast Extension (Tokyo AI Hackathon 2025)"
+description: "Tokyo AI Hackathon 2025で発表したRaycast Extension「Trayce」についてのSpeakerDeck発表資料です。"
+date: "2025-10-30"
+category: "speakerdeck"
+tags: ["SpeakerDeck", "Raycast", "AI", "Hackathon"]
+externalUrl: "https://speakerdeck.com/ota1022/trayce-a-raycast-extension-tokyo-ai-hackathon-2025"
+---

--- a/content/blog/20251204_zenn-aws-ecs-beginner.mdx
+++ b/content/blog/20251204_zenn-aws-ecs-beginner.mdx
@@ -1,0 +1,8 @@
+---
+title: "DockerからECSへ〜AWSの海に出る前に知っておきたいこと"
+description: "DockerからAWS ECSへの移行について、事前に知っておくべきポイントをまとめたZenn記事です。"
+date: "2025-12-04"
+category: "zenn"
+tags: ["Zenn", "Docker", "AWS", "ECS"]
+externalUrl: "https://zenn.dev/iorandd/articles/20251204_aws-ecs-beginner"
+---

--- a/content/blog/20251214_zenn-raycast-tokyo-ai-hackathon.mdx
+++ b/content/blog/20251214_zenn-raycast-tokyo-ai-hackathon.mdx
@@ -1,0 +1,8 @@
+---
+title: "Trayce - A Raycast Extension (Tokyo AI Hackathon 2025)"
+description: "Tokyo AI Hackathon 2025で発表したRaycast Extension「Trayce」についてのZenn記事です。"
+date: "2025-12-14"
+category: "zenn"
+tags: ["Zenn", "Raycast", "AI", "Hackathon"]
+externalUrl: "https://zenn.dev/iorandd/articles/20251214-raycast-tokyo-ai-hackathon"
+---

--- a/content/blog/20251215_zenn-start-raycast-extension-dev.mdx
+++ b/content/blog/20251215_zenn-start-raycast-extension-dev.mdx
@@ -1,0 +1,8 @@
+---
+title: "Raycast Extension開発の始め方"
+description: "Raycast Extensionの開発を始めるためのガイドをまとめたZenn記事です。"
+date: "2025-12-15"
+category: "zenn"
+tags: ["Zenn", "Raycast", "開発"]
+externalUrl: "https://zenn.dev/iorandd/articles/20251215_start-raycast-extension-dev"
+---

--- a/content/blog/20260106_aws-ecs-beginner.mdx
+++ b/content/blog/20260106_aws-ecs-beginner.mdx
@@ -1,7 +1,7 @@
 ---
 title: "AWS ECS: When to Use Service Connect vs Service Discovery"
 date: "2026-01-06"
-category: "tech"
+category: "blog"
 tags: ["AWS", "ECS", "Service Connect", "Service Discovery", "Terraform", "Microservices", "Container"]
 ---
 

--- a/src/components/blog/BlogCard.tsx
+++ b/src/components/blog/BlogCard.tsx
@@ -23,7 +23,7 @@ export default function BlogCard({ post }: BlogCardProps) {
         return 'success';
       case 'activity':
         return 'secondary';
-      case 'award':
+      case 'announcement':
         return 'warning';
       default:
         return 'default';

--- a/src/components/blog/BlogCard.tsx
+++ b/src/components/blog/BlogCard.tsx
@@ -16,13 +16,15 @@ export default function BlogCard({ post }: BlogCardProps) {
   const getCategoryColor = (category: string) => {
     switch (category) {
       case 'blog':
-        return 'info';
+        return 'default';
       case 'zenn':
         return 'primary';
       case 'speakerdeck':
         return 'success';
       case 'activity':
         return 'secondary';
+      case 'award':
+        return 'warning';
       default:
         return 'default';
     }
@@ -43,7 +45,7 @@ export default function BlogCard({ post }: BlogCardProps) {
         <Box sx={{ mb: 1 }}>
           <Chip
             label={frontmatter.category}
-            color={getCategoryColor(frontmatter.category) as 'primary' | 'secondary' | 'success' | 'info' | 'default'}
+            color={getCategoryColor(frontmatter.category) as 'primary' | 'secondary' | 'success' | 'warning' | 'default'}
             size="small"
             sx={{ mb: 1 }}
           />

--- a/src/components/blog/BlogCard.tsx
+++ b/src/components/blog/BlogCard.tsx
@@ -15,8 +15,12 @@ export default function BlogCard({ post }: BlogCardProps) {
 
   const getCategoryColor = (category: string) => {
     switch (category) {
-      case 'tech':
+      case 'blog':
+        return 'info';
+      case 'zenn':
         return 'primary';
+      case 'speakerdeck':
+        return 'success';
       case 'activity':
         return 'secondary';
       default:
@@ -39,7 +43,7 @@ export default function BlogCard({ post }: BlogCardProps) {
         <Box sx={{ mb: 1 }}>
           <Chip
             label={frontmatter.category}
-            color={getCategoryColor(frontmatter.category) as 'primary' | 'secondary' | 'default'}
+            color={getCategoryColor(frontmatter.category) as 'primary' | 'secondary' | 'success' | 'info' | 'default'}
             size="small"
             sx={{ mb: 1 }}
           />
@@ -49,8 +53,10 @@ export default function BlogCard({ post }: BlogCardProps) {
         </Box>
 
         <Link
-          component={NextLink}
-          href={`/blog/${slug}`}
+          component={frontmatter.externalUrl ? 'a' : NextLink}
+          href={frontmatter.externalUrl || `/blog/${slug}`}
+          target={frontmatter.externalUrl ? '_blank' : undefined}
+          rel={frontmatter.externalUrl ? 'noopener noreferrer' : undefined}
           underline="none"
           color="inherit"
         >

--- a/src/components/blog/BlogList.tsx
+++ b/src/components/blog/BlogList.tsx
@@ -44,7 +44,7 @@ export default function BlogList({ initialPosts }: BlogListProps) {
               <MenuItem value="blog">Blog</MenuItem>
               <MenuItem value="zenn">Zenn</MenuItem>
               <MenuItem value="speakerdeck">SpeakerDeck</MenuItem>
-              <MenuItem value="award">Award</MenuItem>
+              <MenuItem value="announcement">Announcement</MenuItem>
               <MenuItem value="activity">Activity</MenuItem>
               <MenuItem value="other">Other</MenuItem>
             </Select>

--- a/src/components/blog/BlogList.tsx
+++ b/src/components/blog/BlogList.tsx
@@ -44,6 +44,7 @@ export default function BlogList({ initialPosts }: BlogListProps) {
               <MenuItem value="blog">Blog</MenuItem>
               <MenuItem value="zenn">Zenn</MenuItem>
               <MenuItem value="speakerdeck">SpeakerDeck</MenuItem>
+              <MenuItem value="award">Award</MenuItem>
               <MenuItem value="activity">Activity</MenuItem>
               <MenuItem value="other">Other</MenuItem>
             </Select>

--- a/src/components/blog/BlogList.tsx
+++ b/src/components/blog/BlogList.tsx
@@ -41,7 +41,9 @@ export default function BlogList({ initialPosts }: BlogListProps) {
               onChange={(e) => setSelectedCategory(e.target.value as BlogCategory | 'all')}
             >
               <MenuItem value="all">All</MenuItem>
-              <MenuItem value="tech">Tech</MenuItem>
+              <MenuItem value="blog">Blog</MenuItem>
+              <MenuItem value="zenn">Zenn</MenuItem>
+              <MenuItem value="speakerdeck">SpeakerDeck</MenuItem>
               <MenuItem value="activity">Activity</MenuItem>
               <MenuItem value="other">Other</MenuItem>
             </Select>

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -58,6 +58,7 @@ export function getPostBySlug(slug: string): BlogPost | null {
 
 /**
  * Get all post slugs (for generateStaticParams)
+ * Excludes posts with externalUrl since they don't need individual pages
  */
 export function getAllPostSlugs(): string[] {
   if (!fs.existsSync(postsDirectory)) {
@@ -67,5 +68,11 @@ export function getAllPostSlugs(): string[] {
   const fileNames = fs.readdirSync(postsDirectory);
   return fileNames
     .filter((fileName) => fileName.endsWith('.mdx'))
+    .filter((fileName) => {
+      const fullPath = path.join(postsDirectory, fileName);
+      const fileContents = fs.readFileSync(fullPath, 'utf8');
+      const { data } = matter(fileContents);
+      return !data.externalUrl;
+    })
     .map((fileName) => fileName.replace(/\.mdx$/, ''));
 }

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -1,4 +1,4 @@
-export type BlogCategory = 'tech' | 'activity' | 'other';
+export type BlogCategory = 'blog' | 'zenn' | 'speakerdeck' | 'activity' | 'other';
 
 export interface BlogPostFrontmatter {
   title: string;
@@ -6,6 +6,7 @@ export interface BlogPostFrontmatter {
   date: string;
   category: BlogCategory;
   tags?: string[];
+  externalUrl?: string;
 }
 
 export interface BlogPost {

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -1,4 +1,4 @@
-export type BlogCategory = 'blog' | 'zenn' | 'speakerdeck' | 'award' | 'activity' | 'other';
+export type BlogCategory = 'blog' | 'zenn' | 'speakerdeck' | 'announcement' | 'activity' | 'other';
 
 export interface BlogPostFrontmatter {
   title: string;

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -1,4 +1,4 @@
-export type BlogCategory = 'blog' | 'zenn' | 'speakerdeck' | 'activity' | 'other';
+export type BlogCategory = 'blog' | 'zenn' | 'speakerdeck' | 'award' | 'activity' | 'other';
 
 export interface BlogPostFrontmatter {
   title: string;


### PR DESCRIPTION
## Summary
- SpeakerDeckとZennへの外部リンク記事をブログに追加できるようにした
- 外部リンク記事はクリックで直接外部サイトに遷移
- カテゴリフィルターでZenn/SpeakerDeckを個別に絞り込み可能

## Changes
- `externalUrl`フィールドを追加（外部リンク用）
- `zenn`と`speakerdeck`カテゴリを追加（色分け対応）
- SpeakerDeck記事4件、Zenn記事3件を追加

## Test plan
- [ ] `/blog`ページで全記事が表示されることを確認
- [ ] 外部リンク記事をクリックで新しいタブでSpeakerDeck/Zennに遷移することを確認
- [ ] カテゴリフィルターでZenn/SpeakerDeckを絞り込めることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)