### PR TITLE
Improve blog readability and syntax highlighting

### DIFF
--- a/content/blog/20260106_aws-ecs-beginner.mdx
+++ b/content/blog/20260106_aws-ecs-beginner.mdx
@@ -49,17 +49,10 @@ Let's say you're building an e-commerce site. With microservices, you might spli
 
 This separation gives you powerful advantages:
 
-**Independent Scaling**
-When you run a flash sale, you can scale up just the Order Service without touching the Recommendation or Product services.
-
-**Better Performance Through Separation**
-The Order Service can respond immediately after an order is placed, while heavy tasks like image processing or report generation run asynchronously in separate services. Since each service scales independently, one service's heavy workload won't impact the others.
-
-**Limited Blast Radius**
-If the Recommendation Service crashes, customers can still place orders. Failures are isolated to individual services.
-
-**Technology Flexibility**
-Use the right tool for each job: Next.js for the frontend, Python for ML-heavy recommendations, and Go for high-performance backend services.
+* **Independent Scaling**: When you run a flash sale, you can scale up just the Order Service without touching the Recommendation or Product services.
+* **Better Performance Through Separation**: The Order Service can respond immediately after an order is placed, while heavy tasks like image processing or report generation run asynchronously in separate services. Since each service scales independently, one service's heavy workload won't impact the others.
+* **Limited Blast Radius**: If the Recommendation Service crashes, customers can still place orders. Failures are isolated to individual services.
+* **Technology Flexibility**: Use the right tool for each job — Next.js for the frontend, Python for ML-heavy recommendations, and Go for high-performance backend services.
 
 ### How ECS Fits In
 
@@ -120,14 +113,9 @@ Service Connect works by automatically injecting an **Envoy sidecar** (a proxy c
 
 Here's what makes it powerful:
 
-**Name-Based Routing**
-Your application containers don't need IP addresses. They connect to other services using simple endpoint names like `my-app:8080`.
-
-**Automatic Traffic Routing**
-When a container tries to connect to a service name, the Envoy sidecar intercepts the request and routes it to the correct destination IP and port.
-
-**Built-In Observability**
-Envoy automatically collects metrics like request counts, latency, and error rates, sending them to CloudWatch. You get visibility into inter-service communication without instrumenting your code.
+* **Name-Based Routing**: Your application containers don't need IP addresses. They connect to other services using simple endpoint names like `my-app:8080`.
+* **Automatic Traffic Routing**: When a container tries to connect to a service name, the Envoy sidecar intercepts the request and routes it to the correct destination IP and port.
+* **Built-In Observability**: Envoy automatically collects metrics like request counts, latency, and error rates, sending them to CloudWatch. You get visibility into inter-service communication without instrumenting your code.
 
 ### Important Limitation
 
@@ -157,14 +145,9 @@ ECS Service Discovery uses the DNS-based approach. When a task starts, it's auto
 
 ### Key Benefits
 
-**Universal Access**
-Any service within your VPC can access ECS tasks using DNS names—Lambda functions, EC2 instances, other ECS services, or internal systems.
-
-**Standard DNS Resolution**
-No special client configuration needed. Services use standard DNS lookups to find endpoints.
-
-**Automatic Registration**
-Tasks are registered and deregistered automatically as they start and stop.
+* **Universal Access**: Any service within your VPC can access ECS tasks using DNS names — Lambda functions, EC2 instances, other ECS services, or internal systems.
+* **Standard DNS Resolution**: No special client configuration needed. Services use standard DNS lookups to find endpoints.
+* **Automatic Registration**: Tasks are registered and deregistered automatically as they start and stop.
 
 ---
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,9 @@
 const nextConfig = {
   // assetPrefix: '/portfolio/',
-  output: 'export',
+  // output: 'export' breaks `next dev` for dynamic routes in Next.js 14,
+  // so only enable it for production builds.
+  ...(process.env.NODE_ENV === 'production' && { output: 'export' }),
+  transpilePackages: ['rehype-pretty-code', 'shiki'],
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "next-mdx-remote": "^5.0.0",
         "react": "^18",
         "react-dom": "^18",
-        "rehype-highlight": "^7.0.2",
+        "rehype-pretty-code": "^0.14.1",
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
@@ -1270,6 +1270,73 @@
       "integrity": "sha512-0HejFckBN2W+ucM6cUOlwsByTKt9/+0tWhqUffNIcHqCXkthY/mZ7AuYPK/2IIaGWhdl0h+tICDO0ssLMd6XMQ==",
       "dev": true
     },
+    "node_modules/@shikijs/core": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.21.0.tgz",
+      "integrity": "sha512-AXSQu/2n1UIQekY8euBJlvFYZIw0PHY63jUzGbrOma4wPxzznJXTXkri+QcHeBNaFxiiOljKxxJkVSoB3PjbyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.21.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.21.0.tgz",
+      "integrity": "sha512-ATwv86xlbmfD9n9gKRiwuPpWgPENAWCLwYCGz9ugTJlsO2kOzhOkvoyV/UD+tJ0uT7YRyD530x6ugNSffmvIiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.21.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.21.0.tgz",
+      "integrity": "sha512-OYknTCct6qiwpQDqDdf3iedRdzj6hFlOPv5hMvI+hkWfCKs5mlJ4TXziBG9nyabLwGulrUjHiCq3xCspSzErYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.21.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.21.0.tgz",
+      "integrity": "sha512-g6mn5m+Y6GBJ4wxmBYqalK9Sp0CFkUqfNzUy2pJglUginz6ZpWbaWjDB4fbQ/8SHzFjYbtU6Ddlp1pc+PPNDVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.21.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.21.0.tgz",
+      "integrity": "sha512-BAE4cr9EDiZyYzwIHEk7JTBJ9CzlPuM4PchfcA5ao1dWXb25nv6hYsoDiBq2aZK9E3dlt3WB78uI96UESD+8Mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.21.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.21.0.tgz",
+      "integrity": "sha512-zGrWOxZ0/+0ovPY7PvBU2gIS9tmhSUUt30jAcNV0Bq0gb2S98gwfjIs1vxlmH5zM7/4YxLamT6ChlqqAJmPPjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -2431,6 +2498,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -3807,10 +3886,48 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hast-util-is-element": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
-      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -3848,6 +3965,29 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -3875,16 +4015,13 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-to-text": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
-      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
       "license": "MIT",
       "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "hast-util-is-element": "^3.0.0",
-        "unist-util-find-after": "^5.0.0"
+        "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3904,13 +4041,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/highlight.js": {
-      "version": "11.11.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12.0.0"
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -3919,6 +4064,16 @@
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
       "dependencies": {
         "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ignore": {
@@ -4634,21 +4789,6 @@
       },
       "bin": {
         "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/lowlight": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
-      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "devlop": "^1.0.0",
-        "highlight.js": "~11.11.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/lru-cache": {
@@ -5999,6 +6139,23 @@
         "wrappy": "1"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
+      "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.4.tgz",
+      "integrity": "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.1",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -6097,6 +6254,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-numeric-range": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz",
+      "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==",
+      "license": "ISC"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -6419,6 +6594,30 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
@@ -6437,21 +6636,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/rehype-highlight": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-7.0.2.tgz",
-      "integrity": "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==",
+    "node_modules/rehype-parse": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
-        "hast-util-to-text": "^4.0.0",
-        "lowlight": "^3.0.0",
-        "unist-util-visit": "^5.0.0",
-        "vfile": "^6.0.0"
+        "hast-util-from-html": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-pretty-code": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/rehype-pretty-code/-/rehype-pretty-code-0.14.1.tgz",
+      "integrity": "sha512-IpG4OL0iYlbx78muVldsK86hdfNoht0z63AP7sekQNW2QOTmjxB7RbTO+rhIYNGRljgHxgVZoPwUl6bIC9SbjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.4",
+        "hast-util-to-string": "^3.0.0",
+        "parse-numeric-range": "^1.3.0",
+        "rehype-parse": "^9.0.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "shiki": "^1.0.0 || ^2.0.0 || ^3.0.0"
       }
     },
     "node_modules/rehype-recma": {
@@ -6784,6 +7001,23 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.21.0.tgz",
+      "integrity": "sha512-N65B/3bqL/TI2crrXr+4UivctrAGEjmsib5rPMMPpFp1xAx/w03v8WZ9RDDFYteXoEgY7qZ4HGgl5KBIu1153w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/core": "3.21.0",
+        "@shikijs/engine-javascript": "3.21.0",
+        "@shikijs/engine-oniguruma": "3.21.0",
+        "@shikijs/langs": "3.21.0",
+        "@shikijs/themes": "3.21.0",
+        "@shikijs/types": "3.21.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/side-channel": {
@@ -7379,20 +7613,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/unist-util-find-after": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
-      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
@@ -7564,6 +7784,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vfile-matter": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/vfile-matter/-/vfile-matter-5.0.1.tgz",
@@ -7605,6 +7839,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "next-mdx-remote": "^5.0.0",
     "react": "^18",
     "react-dom": "^18",
-    "rehype-highlight": "^7.0.2",
+    "rehype-pretty-code": "^0.14.1",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -6,7 +6,7 @@ import { format } from 'date-fns';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 import NextLink from 'next/link';
 import { notFound } from 'next/navigation';
-import rehypeHighlight from 'rehype-highlight';
+import rehypePrettyCode from 'rehype-pretty-code';
 import remarkGfm from 'remark-gfm';
 
 const PLACEHOLDER_SLUG = '__blog-placeholder__';
@@ -102,7 +102,7 @@ export default function BlogPostPage({ params }: BlogPostPageProps) {
           ← Back to Blog
         </Link>
 
-        <Paper elevation={2} sx={{ p: 4, mt: 2 }}>
+        <Paper elevation={2} sx={{ p: { xs: 2, sm: 3, md: 4 }, mt: 2 }}>
           <Box sx={{ mb: 3 }}>
             {(() => {
               const colorValue = getCategoryColor(frontmatter.category);
@@ -156,7 +156,9 @@ export default function BlogPostPage({ params }: BlogPostPageProps) {
               options={{
                 mdxOptions: {
                   remarkPlugins: [remarkGfm],
-                  rehypePlugins: [rehypeHighlight],
+                  rehypePlugins: [
+                    [rehypePrettyCode, { theme: 'github-dark', keepBackground: true }],
+                  ],
                 },
               }}
             />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,17 +39,6 @@ export default function RootLayout({
             `,
           }}
         />
-        {/* Syntax highlighting CSS */}
-        <link
-          rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css"
-          media="(prefers-color-scheme: dark)"
-        />
-        <link
-          rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css"
-          media="(prefers-color-scheme: light)"
-        />
       </head>
       <body className={inconsolata.className}>
         <ColorModeContext.Provider value={colorMode}>

--- a/src/components/blog/CodeBlock.tsx
+++ b/src/components/blog/CodeBlock.tsx
@@ -1,28 +1,27 @@
 'use client';
 
-import { Box, IconButton, Tooltip, useTheme } from '@mui/material';
+import { Box, IconButton, Tooltip } from '@mui/material';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CheckIcon from '@mui/icons-material/Check';
-import { useState } from 'react';
+import { useState, type CSSProperties } from 'react';
 
 interface CodeBlockProps {
   children: React.ReactNode;
-  className?: string;
+  style?: CSSProperties;
+  [key: string]: unknown;
 }
 
-export function CodeBlock({ children, className }: CodeBlockProps) {
+export function CodeBlock({ children, style, ...props }: CodeBlockProps) {
   const [copied, setCopied] = useState(false);
-  const theme = useTheme();
+  const language = props['data-language'] as string | undefined;
 
   const handleCopy = () => {
-    // Extract text content from children
     const code = extractTextContent(children);
     navigator.clipboard.writeText(code);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
 
-  // Helper function to extract text from React nodes
   const extractTextContent = (node: React.ReactNode): string => {
     if (typeof node === 'string') return node;
     if (typeof node === 'number') return String(node);
@@ -36,29 +35,51 @@ export function CodeBlock({ children, className }: CodeBlockProps) {
   return (
     <Box
       component="pre"
+      style={style}
       sx={{
         position: 'relative',
-        bgcolor: 'rgba(255, 255, 255, 0.05)',
         p: 2,
+        pt: language ? 4.5 : 2,
         borderRadius: 1,
         overflow: 'auto',
         my: 2,
         fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+        fontSize: '0.9em',
+        lineHeight: 1.7,
+        ...(!style?.backgroundColor && {
+          bgcolor: '#24292e',
+          color: '#e1e4e8',
+        }),
       }}
     >
-      <Box component="code" className={className}>
-        {children}
-      </Box>
+      {language && (
+        <Box
+          component="span"
+          sx={{
+            position: 'absolute',
+            top: 8,
+            left: 16,
+            fontSize: '0.75em',
+            color: 'rgba(255, 255, 255, 0.4)',
+            textTransform: 'uppercase',
+            letterSpacing: '0.05em',
+            userSelect: 'none',
+          }}
+        >
+          {language}
+        </Box>
+      )}
+      {children}
       <Tooltip title={copied ? 'Copied!' : 'Copy code'}>
         <IconButton
           onClick={handleCopy}
           sx={{
             position: 'absolute',
-            top: 16,
-            right: 16,
-            color: 'rgba(255, 255, 255, 0.7)',
+            top: 8,
+            right: 8,
+            color: 'rgba(255, 255, 255, 0.5)',
             '&:hover': {
-              color: 'rgba(255, 255, 255, 1)',
+              color: 'rgba(255, 255, 255, 0.9)',
               bgcolor: 'rgba(255, 255, 255, 0.1)',
             },
           }}

--- a/src/components/blog/MDXComponents.tsx
+++ b/src/components/blog/MDXComponents.tsx
@@ -23,7 +23,7 @@ export const mdxComponents: MDXComponents = {
     </Typography>
   ),
   h2: ({ children }) => (
-    <Typography variant="h4" component="h2" gutterBottom sx={{ mt: 3, mb: 2 }}>
+    <Typography variant="h4" component="h2" gutterBottom sx={{ mt: 4, mb: 2, pb: 1, borderBottom: 1, borderColor: 'grey.600' }}>
       {children}
     </Typography>
   ),
@@ -38,7 +38,7 @@ export const mdxComponents: MDXComponents = {
     </Typography>
   ),
   p: ({ children }) => (
-    <Typography variant="body1" paragraph>
+    <Typography variant="body1" paragraph sx={{ lineHeight: 1.8 }}>
       {children}
     </Typography>
   ),
@@ -58,7 +58,7 @@ export const mdxComponents: MDXComponents = {
     </Box>
   ),
   li: ({ children }) => (
-    <Typography component="li" variant="body1" sx={{ mb: 0.5 }}>
+    <Typography component="li" variant="body1" sx={{ mb: 0.5, lineHeight: 1.8 }}>
       {children}
     </Typography>
   ),
@@ -78,8 +78,9 @@ export const mdxComponents: MDXComponents = {
       {children}
     </Box>
   ),
-  code: ({ children, className }) => {
-    const isInline = !className;
+  code: ({ children, className, ...props }) => {
+    // rehype-pretty-code uses data-language for fenced code blocks
+    const isInline = !className && !(props as Record<string, unknown>)['data-language'];
     if (isInline) {
       return (
         <Box
@@ -98,17 +99,11 @@ export const mdxComponents: MDXComponents = {
         </Box>
       );
     }
-    // For fenced code blocks, return code element with className preserved
-    // The pre component will extract props from this element
-    return <code className={className}>{children}</code>;
+    // For fenced code blocks, preserve all props from rehype-pretty-code
+    return <code className={className} {...props}>{children}</code>;
   },
-  pre: ({ children }) => {
-    // Extract className from code element if it exists
-    const codeElement = children as any;
-    const className = codeElement?.props?.className;
-    const codeContent = codeElement?.props?.children;
-
-    return <CodeBlock className={className}>{codeContent}</CodeBlock>;
+  pre: ({ children, ...rest }) => {
+    return <CodeBlock {...rest}>{children}</CodeBlock>;
   },
   hr: () => (
     <Box
@@ -127,12 +122,13 @@ export const mdxComponents: MDXComponents = {
 
     return (
       <Box
+        component="span"
         sx={{
+          display: 'flex',
           bgcolor: isTransparent ? 'transparent' : '#ffffff',
           p: 2,
           borderRadius: 1,
           my: 2,
-          display: 'flex',
           justifyContent: 'center',
         }}
       >
@@ -151,7 +147,7 @@ export const mdxComponents: MDXComponents = {
   },
   table: ({ children }) => (
     <TableContainer sx={{ my: 3, overflowX: 'auto' }}>
-      <Table sx={{ minWidth: 650, border: 1, borderColor: 'divider' }}>{children}</Table>
+      <Table sx={{ border: 1, borderColor: 'divider' }}>{children}</Table>
     </TableContainer>
   ),
   thead: ({ children }) => <TableHead>{children}</TableHead>,

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -2,7 +2,7 @@
 
 import baseTheme from '@/theme/theme';
 import type { Theme } from '@mui/material/styles';
-import { createTheme } from '@mui/material/styles';
+import { createTheme, responsiveFontSizes } from '@mui/material/styles';
 import { createContext, useEffect, useMemo, useState } from 'react';
 
 type ThemeMode = 'light' | 'dark';
@@ -48,7 +48,7 @@ export function ToggleColorMode(): {
   const theme = useMemo(() => {
     // Create theme according to mode
     if (mode === 'light') {
-      return createTheme({
+      return responsiveFontSizes(createTheme({
         ...baseTheme,
         palette: {
           ...baseTheme.palette,
@@ -79,16 +79,16 @@ export function ToggleColorMode(): {
             },
           },
         },
-      });
+      }));
     }
     // For dark mode, use baseTheme as is
-    return createTheme({
+    return responsiveFontSizes(createTheme({
       ...baseTheme,
       palette: {
         ...baseTheme.palette,
         mode,
       },
-    });
+    }));
   }, [mode]);
 
   return { colorMode, theme };

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -69,6 +69,19 @@ a {
   text-decoration: none;
 }
 
+/* rehype-pretty-code */
+figure[data-rehype-pretty-code-figure] {
+  margin: 0;
+}
+
+[data-rehype-pretty-code-figure] code {
+  display: grid;
+}
+
+[data-rehype-pretty-code-figure] [data-line] {
+  padding: 0 0.5rem;
+}
+
 @media (prefers-color-scheme: dark) {
   html {
     color-scheme: dark;


### PR DESCRIPTION
## Summary
- **シンタックスハイライト**: `rehype-highlight` → `rehype-pretty-code`（Shiki / github-dark テーマ）に置換。Zenn と同等の色付けをインラインスタイルで実現し、CDN の highlight.js CSS を削除
- **レスポンシブ対応**: `responsiveFontSizes()` で見出しサイズをスマホ向けに自動縮小、Paper の余白もブレークポイントで調整
- **読みやすさ改善**: 本文の行間を 1.8 に、h2 に区切り線追加、テーブルの `minWidth` 削除でスマホ横スクロール解消
- **記事フォーマット統一**: 太字見出し＋説明文を `* **見出し**: 説明` のリストスタイルに統一
- **バグ修正**: 画像の hydration エラー修正、`next dev` での `generateStaticParams` エラー修正

## Test plan
- [ ] `npm run dev` でブログ記事ページが表示されること
- [ ] コードブロックに Shiki の github-dark テーマでシンタックスハイライトが適用されていること
- [ ] スマホ幅でタイトル・見出しが適切に縮小されること
- [ ] スマホ幅で Paper の余白が狭くなること
- [ ] h2 見出しの下に区切り線が表示されること（ダーク・ライト両モード）
- [ ] テーブルがスマホで横スクロールなしに収まること
- [ ] `npm run build` が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)