### PR TITLE
feat(blog): ブログカード全体をクリッカブルにして遷移を改善

### DIFF
--- a/src/components/blog/BlogCard.tsx
+++ b/src/components/blog/BlogCard.tsx
@@ -30,73 +30,78 @@ export default function BlogCard({ post }: BlogCardProps) {
     }
   };
 
-  return (
-    <Card
-      sx={{
-        mb: 3,
-        transition: 'transform 0.2s, box-shadow 0.2s',
-        '&:hover': {
-          transform: 'translateY(-4px)',
-          boxShadow: 4,
-        },
-      }}
-    >
-      <CardContent>
-        <Box sx={{ mb: 1 }}>
-          {(() => {
-            const colorValue = getCategoryColor(frontmatter.category);
-            const isCustomColor = typeof colorValue === 'object';
-            return (
-              <Chip
-                label={frontmatter.category}
-                color={isCustomColor ? 'default' : colorValue as 'primary' | 'secondary' | 'success' | 'warning' | 'default'}
-                size="small"
-                sx={{
-                  mb: 1,
-                  ...(isCustomColor && {
-                    backgroundColor: colorValue.bg,
-                    color: colorValue.text,
-                  }),
-                }}
-              />
-            );
-          })()}
-          <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
-            {formattedDate}
-          </Typography>
-        </Box>
+  const href = frontmatter.externalUrl || `/blog/${slug}`;
+  const isExternal = !!frontmatter.externalUrl;
 
-        <Link
-          component={frontmatter.externalUrl ? 'a' : NextLink}
-          href={frontmatter.externalUrl || `/blog/${slug}`}
-          target={frontmatter.externalUrl ? '_blank' : undefined}
-          rel={frontmatter.externalUrl ? 'noopener noreferrer' : undefined}
-          underline="none"
-          color="inherit"
-        >
+  return (
+    <Link
+      component={isExternal ? 'a' : NextLink}
+      href={href}
+      target={isExternal ? '_blank' : undefined}
+      rel={isExternal ? 'noopener noreferrer' : undefined}
+      underline="none"
+      color="inherit"
+      display="block"
+      sx={{ mb: 3 }}
+    >
+      <Card
+        sx={{
+          transition: 'transform 0.2s, box-shadow 0.2s',
+          '&:hover': {
+            transform: 'translateY(-4px)',
+            boxShadow: 4,
+          },
+          cursor: 'pointer',
+        }}
+      >
+        <CardContent>
+          <Box sx={{ mb: 1 }}>
+            {(() => {
+              const colorValue = getCategoryColor(frontmatter.category);
+              const isCustomColor = typeof colorValue === 'object';
+              return (
+                <Chip
+                  label={frontmatter.category}
+                  color={isCustomColor ? 'default' : colorValue as 'primary' | 'secondary' | 'success' | 'warning' | 'default'}
+                  size="small"
+                  sx={{
+                    mb: 1,
+                    ...(isCustomColor && {
+                      backgroundColor: colorValue.bg,
+                      color: colorValue.text,
+                    }),
+                  }}
+                />
+              );
+            })()}
+            <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+              {formattedDate}
+            </Typography>
+          </Box>
+
           <Typography variant="h5" component="h2" gutterBottom sx={{ mb: 1 }}>
             {frontmatter.title}
           </Typography>
-        </Link>
 
-        <Typography variant="body2" color="text.secondary" paragraph>
-          {frontmatter.description}
-        </Typography>
+          <Typography variant="body2" color="text.secondary" paragraph>
+            {frontmatter.description}
+          </Typography>
 
-        {frontmatter.tags && frontmatter.tags.length > 0 && (
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1 }}>
-            {frontmatter.tags.map((tag) => (
-              <Chip
-                key={tag}
-                label={tag}
-                size="small"
-                variant="outlined"
-                sx={{ fontSize: '0.7rem' }}
-              />
-            ))}
-          </Box>
-        )}
-      </CardContent>
-    </Card>
+          {frontmatter.tags && frontmatter.tags.length > 0 && (
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1 }}>
+              {frontmatter.tags.map((tag) => (
+                <Chip
+                  key={tag}
+                  label={tag}
+                  size="small"
+                  variant="outlined"
+                  sx={{ fontSize: '0.7rem' }}
+                />
+              ))}
+            </Box>
+          )}
+        </CardContent>
+      </Card>
+    </Link>
   );
 }


### PR DESCRIPTION
タイトルのみリンクだった BlogCard を、カード全体をリンクで
ラップする構造に変更。概要テキストやタグ部分をクリックしても
該当記事・外部サイトに遷移できるようにした。

https://claude.ai/code/session_01UNThqEPmyuh3g5XkFdCuUL