### PR TITLE
fix(blog): ブログ本文の textAlign: justify を削除

### DIFF
--- a/src/components/blog/MDXComponents.tsx
+++ b/src/components/blog/MDXComponents.tsx
@@ -39,7 +39,7 @@ export const mdxComponents: MDXComponents = {
     </Typography>
   ),
   p: ({ children }) => (
-    <Typography variant="body1" paragraph sx={{ lineHeight: 1.8, textAlign: 'justify' }}>
+    <Typography variant="body1" paragraph sx={{ lineHeight: 1.8 }}>
       {children}
     </Typography>
   ),
@@ -59,7 +59,7 @@ export const mdxComponents: MDXComponents = {
     </Box>
   ),
   li: ({ children }) => (
-    <Typography component="li" variant="body1" sx={{ mb: 0.5, lineHeight: 1.8, textAlign: 'justify' }}>
+    <Typography component="li" variant="body1" sx={{ mb: 0.5, lineHeight: 1.8 }}>
       {children}
     </Typography>
   ),


### PR DESCRIPTION
両端揃えはモバイルで単語間のスペースが不均等になり読みにくいため、
p・li 要素の textAlign: 'justify' を除去してデフォルト(left)に戻す。

https://claude.ai/code/session_01UNThqEPmyuh3g5XkFdCuUL