### PR TITLE
feat(blog): SpeakerDeck「コミットの『なぜ』を読む」カードを追加

### DIFF
--- a/content/blog/20260622_speakerdeck-commit-no-naze-wo-yomu.mdx
+++ b/content/blog/20260622_speakerdeck-commit-no-naze-wo-yomu.mdx
@@ -1,0 +1,8 @@
+---
+title: "コミットの「なぜ」を読む"
+description: "めぐろLT #37「AI×チーム開発、みんなどうしてる？」での発表資料。Entire CLI を使って AI とのセッションを Git に残し、コミットの「なぜ」を読めるようにする取り組みを紹介します。"
+date: "2026-06-22"
+category: "speakerdeck"
+tags: ["SpeakerDeck", "AI", "Git", "Claude Code", "チーム開発", "LT"]
+externalUrl: "https://speakerdeck.com/ota1022/komitutono-naze-wodu-mu"
+---

--- a/content/blog/20260623_speakerdeck-commit-no-naze-wo-yomu.mdx
+++ b/content/blog/20260623_speakerdeck-commit-no-naze-wo-yomu.mdx
@@ -1,7 +1,7 @@
 ---
 title: "コミットの「なぜ」を読む"
 description: "めぐろLT #37「AI×チーム開発、みんなどうしてる？」での発表資料。Entire CLI を使って AI とのセッションを Git に残し、コミットの「なぜ」を読めるようにする取り組みを紹介します。"
-date: "2026-06-22"
+date: "2026-06-23"
 category: "speakerdeck"
 tags: ["SpeakerDeck", "AI", "Git", "Claude Code", "チーム開発", "LT"]
 externalUrl: "https://speakerdeck.com/ota1022/komitutono-naze-wodu-mu"


### PR DESCRIPTION
## Summary
- めぐろLT #37「AI×チーム開発、みんなどうしてる？」での発表資料を SpeakerDeck カテゴリのブログエントリとして追加
- externalUrl で https://speakerdeck.com/ota1022/komitutono-naze-wodu-mu に遷移

## Test plan
- [ ] `npm run dev` でブログ一覧に新しいカードが表示されることを確認
- [ ] カードをクリックすると SpeakerDeck にリンクすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)