### PR TITLE
feat: Add 2026 Japan AWS Jr. Champion to blog and home

### DIFF
--- a/content/blog/20260625_aws-jr-champions-2026.mdx
+++ b/content/blog/20260625_aws-jr-champions-2026.mdx
@@ -1,0 +1,26 @@
+---
+title: "Named a 2026 Japan AWS Jr. Champion"
+description: "An AWS Japan program recognizing early-career engineers active in the AWS community."
+date: "2026-06-25"
+category: "announcement"
+tags: ["AWS", "AWS Jr. Champions", "Community"]
+---
+
+I've been named a **2026 Japan AWS Jr. Champion**, one of just 114 engineers recognized nationwide this year.
+
+## What Is the AWS Jr. Champions Program?
+
+AWS Jr. Champions is an official recognition program run by Amazon Web Services (AWS) in Japan. Each year it selects a small cohort of early-career engineers—those with roughly one to three years of professional experience—nominated by AWS Partner Network companies from across the country. Now in its fourth year, the 2026 cohort comprises 114 members, each serving a one-year term.
+
+The program recognizes engineers who demonstrate strong technical ability, leadership within their organizations, and contribution to the wider AWS community. Selection weighs technical accomplishments and AWS expertise, the ability to influence peers and lead internal AWS communities, and public knowledge sharing through writing and talks.
+
+My own contributions have centered on technical writing about AWS, including articles on Amazon ECS networking and migrating AWS resources to infrastructure-as-code with Terraform.
+
+---
+
+*I'm listed on the official roster as 太田 暢 (Itaru Ota), 3-shake Inc.*
+
+Sources:
+
+- [2026 Japan AWS Jr. Champions のご紹介 — AWS Partner Network (APN) Blog](https://aws.amazon.com/jp/blogs/psa/2026-japan-aws-jr-champions/)
+- [スリーシェイク所属のエンジニアが「2026 Japan All AWS Certifications Engineers」「2026 Japan AWS Jr.Champions」に選出 — 3-shake Inc. press release](https://sreake.com/news/2026-japan-all-aws-certifications-engineers2026-japan-aws-jr-champions/)

--- a/src/app/components/Awards/page.tsx
+++ b/src/app/components/Awards/page.tsx
@@ -17,7 +17,8 @@ const Awards: FC = () => {
             <Link
               href="https://aws.amazon.com/jp/blogs/psa/2026-japan-aws-jr-champions/"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
+              aria-label="2026 Japan AWS Jr. Champions announcement"
             >
               [URL]
             </Link>
@@ -27,7 +28,8 @@ const Awards: FC = () => {
             <Link
               href="https://event.dbsj.org/deim2022/post/awards.html"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
+              aria-label="DEIM2022 Student Presentation Award details"
             >
               [URL]
             </Link>
@@ -37,7 +39,8 @@ const Awards: FC = () => {
             <Link
               href="https://sites.google.com/view/imedia-ws/imedia2021"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
+              aria-label="imedia2021 Data Broad Award details"
             >
               [URL]
             </Link>
@@ -47,7 +50,8 @@ const Awards: FC = () => {
             <Link
               href="https://x.com/NAIST_MAIN/status/1429671012770009093?s=20&t=TW6BTHQ4EXVxJPVso1mbLg"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
+              aria-label="GEIOT2021 in NAIST 1st Prize details"
             >
               [URL]
             </Link>

--- a/src/app/components/Awards/page.tsx
+++ b/src/app/components/Awards/page.tsx
@@ -13,6 +13,16 @@ const Awards: FC = () => {
       <Typography variant="body1" component="div" sx={{ marginLeft: 2 }}>
         <ul>
           <li>
+            2026 Japan AWS Jr. Champion, AWS,{' '}
+            <Link
+              href="https://aws.amazon.com/jp/blogs/psa/2026-japan-aws-jr-champions/"
+              target="_blank"
+              rel="noopener"
+            >
+              [URL]
+            </Link>
+          </li>
+          <li>
             Student Presentation Award, DEIM2022,{' '}
             <Link
               href="https://event.dbsj.org/deim2022/post/awards.html"

--- a/src/app/components/Awards/page.tsx
+++ b/src/app/components/Awards/page.tsx
@@ -13,7 +13,7 @@ const Awards: FC = () => {
       <Typography variant="body1" component="div" sx={{ marginLeft: 2 }}>
         <ul>
           <li>
-            2026 Japan AWS Jr. Champion, AWS,{' '}
+            2026 Japan AWS Jr. Champion, AWS{' '}
             <Link
               href="https://aws.amazon.com/jp/blogs/psa/2026-japan-aws-jr-champions/"
               target="_blank"
@@ -23,7 +23,7 @@ const Awards: FC = () => {
             </Link>
           </li>
           <li>
-            Student Presentation Award, DEIM2022,{' '}
+            Student Presentation Award, DEIM2022{' '}
             <Link
               href="https://event.dbsj.org/deim2022/post/awards.html"
               target="_blank"
@@ -43,7 +43,7 @@ const Awards: FC = () => {
             </Link>
           </li>
           <li>
-            1st Prize, GEIOT2021 in NAIST,{' '}
+            1st Prize, GEIOT2021 in NAIST{' '}
             <Link
               href="https://x.com/NAIST_MAIN/status/1429671012770009093?s=20&t=TW6BTHQ4EXVxJPVso1mbLg"
               target="_blank"

--- a/src/components/AboutMe.tsx
+++ b/src/components/AboutMe.tsx
@@ -31,6 +31,12 @@ const AboutMe = (): React.ReactNode => {
               Specialty, etc.
             </Typography>
           </li>
+          <li>
+            <Typography variant="subtitle1">
+              Named a 2026 Japan AWS Jr. Champion, one of just 114 engineers
+              recognized nationwide by AWS.
+            </Typography>
+          </li>
         </ul>
       </Typography>
     </Paper>


### PR DESCRIPTION
## Summary

Add a blog post and home-page entries for being named a 2026 Japan AWS Jr. Champion.

## Changes

- New blog post (English, with body): `content/blog/20260625_aws-jr-champions-2026.mdx`
- About Me: one line added
- Awards: new entry, plus unified the `[URL]` comma style across items