### PR TITLE
[codex] Polish English portfolio content

### DIFF
--- a/content/blog/20250528_cursor-team-introduction.mdx
+++ b/content/blog/20250528_cursor-team-introduction.mdx
@@ -1,8 +1,8 @@
 ---
-title: "AIコードエディタは開発を変えるか？Cursorをチームに導入して1ヶ月経った本音"
-description: "Qiita Bashでの発表資料。Cursorをチームに導入した1ヶ月間の実体験と、生産性向上の事例や課題を共有しています。"
+title: "Can AI Code Editors Change Development? One Month After Introducing Cursor to a Team (Japanese)"
+description: "Slides from Qiita Bash, sharing firsthand lessons from one month of introducing Cursor to a team, including productivity gains and challenges."
 date: "2025-05-28"
 category: "speakerdeck"
-tags: ["SpeakerDeck", "Cursor", "AI", "チーム開発"]
+tags: ["SpeakerDeck", "Cursor", "AI", "Team Development"]
 externalUrl: "https://speakerdeck.com/ota1022/aikodoedeitahakai-fa-wobian-eruka-cursorwotimunidao-ru-site1keyue-jing-tutaben-yin"
 ---

--- a/content/blog/20250528_qiita-bash-presentation-video.mdx
+++ b/content/blog/20250528_qiita-bash-presentation-video.mdx
@@ -1,8 +1,8 @@
 ---
-title: "【登壇動画】AIコードエディタは開発を変えるか？Cursorをチームに導入して1ヶ月経った本音"
-description: "Qiita Bash #5 での登壇動画。Cursorをチームに導入した1ヶ月間の実体験と、生産性向上の事例や課題を共有しています。"
+title: "Talk Recording: Can AI Code Editors Change Development? One Month After Introducing Cursor to a Team (Japanese)"
+description: "A talk recording from Qiita Bash #5, sharing firsthand lessons from one month of introducing Cursor to a team, including productivity gains and challenges."
 date: "2025-05-28"
 category: "activity"
-tags: ["登壇", "Cursor", "AI", "チーム開発", "Qiita Bash"]
+tags: ["Talk", "Cursor", "AI", "Team Development", "Qiita Bash"]
 externalUrl: "https://youtu.be/JQPfFtRd45A?si=9E8_fbAqoV4SBO80"
 ---

--- a/content/blog/20250821_docker-to-ecs.mdx
+++ b/content/blog/20250821_docker-to-ecs.mdx
@@ -1,6 +1,6 @@
 ---
-title: "DockerからECSへ 〜 AWSの海に出る前に知っておきたいこと 〜"
-description: "JAWS-UGコンテナ支部での発表資料。LocalStackを活用したローカル環境構築など、ECS移行前に理解しておくべきポイントを解説しています。"
+title: "From Docker to ECS: What to Know Before Moving to AWS (Japanese)"
+description: "Slides from JAWS-UG Container Branch, covering key concepts to understand before migrating to ECS, including local environment setup with LocalStack."
 date: "2025-08-21"
 category: "speakerdeck"
 tags: ["SpeakerDeck", "Docker", "AWS", "ECS", "LocalStack", "CI/CD"]

--- a/content/blog/20250925_github-actions-aws-oidc.mdx
+++ b/content/blog/20250925_github-actions-aws-oidc.mdx
@@ -1,8 +1,8 @@
 ---
-title: "GitHub Actions × AWS OIDC連携の仕組みと経緯を理解する"
-description: "3-shake SRE Tech Talkでの発表資料。OIDCプロトコルの仕組み、OIDC以前のアクセスキー方式の課題、OIDC標準化の歴史的経緯を解説しています。"
+title: "Understanding GitHub Actions and AWS OIDC Integration (Japanese)"
+description: "Slides from 3-shake SRE Tech Talk, explaining the OIDC protocol, the limitations of access-key-based workflows before OIDC, and the historical background of OIDC standardization."
 date: "2025-09-25"
 category: "speakerdeck"
-tags: ["SpeakerDeck", "GitHub Actions", "AWS", "OIDC", "CI/CD", "セキュリティ"]
+tags: ["SpeakerDeck", "GitHub Actions", "AWS", "OIDC", "CI/CD", "Security"]
 externalUrl: "https://speakerdeck.com/ota1022/github-actions-x-aws-oidclian-xi-noshi-zu-mitojing-wei-woli-jie-suru"
 ---

--- a/content/blog/20251204_zenn-aws-ecs-beginner.mdx
+++ b/content/blog/20251204_zenn-aws-ecs-beginner.mdx
@@ -1,6 +1,6 @@
 ---
-title: "ECSのService ConnectとService Discoveryの違いを理解する"
-description: "Amazon ECSにおけるマイクロサービス間通信の2つの主要な仕組み、Service ConnectとService Discoveryの機能的な違いや使い分けについて解説したZenn記事です。"
+title: "Understanding the Difference Between ECS Service Connect and Service Discovery (Japanese)"
+description: "A Zenn article explaining the functional differences and use cases for Service Connect and Service Discovery, two key mechanisms for microservice communication on Amazon ECS."
 date: "2025-12-04"
 category: "zenn"
 tags: ["Zenn", "AWS", "ECS", "Terraform"]

--- a/content/blog/20251214_zenn-raycast-tokyo-ai-hackathon.mdx
+++ b/content/blog/20251214_zenn-raycast-tokyo-ai-hackathon.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Raycast Community Japan 主催イベントに3連続参加した話"
-description: "Raycast Community Japanのアイデアソン、ハッカソン、Meetupに参加し、「Trayce」というRaycast Extensionを開発した体験記です。"
+title: "Joining Three Consecutive Raycast Community Japan Events (Japanese)"
+description: "A Zenn article about participating in Raycast Community Japan's ideathon, hackathon, and meetup, and building a Raycast Extension called Trayce."
 date: "2025-12-14"
 category: "zenn"
-tags: ["Zenn", "Raycast", "AI", "Hackathon", "コミュニティ"]
+tags: ["Zenn", "Raycast", "AI", "Hackathon", "Community"]
 externalUrl: "https://zenn.dev/iorandd/articles/20251214-raycast-tokyo-ai-hackathon"
 ---

--- a/content/blog/20251215_zenn-start-raycast-extension-dev.mdx
+++ b/content/blog/20251215_zenn-start-raycast-extension-dev.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Raycast Extension 開発のすすめ"
-description: "TypeScriptとReactを使ったRaycast Extension開発のガイドです。Todoリストアプリの作成からRaycast Storeへの公開までを解説しています。"
+title: "Getting Started with Raycast Extension Development (Japanese)"
+description: "A guide to building Raycast Extensions with TypeScript and React, from creating a todo app to publishing it on the Raycast Store."
 date: "2025-12-15"
 category: "zenn"
 tags: ["Zenn", "Raycast", "TypeScript", "React"]

--- a/content/blog/20260131_zenn-aws-how-to-use-terraformer.mdx
+++ b/content/blog/20260131_zenn-aws-how-to-use-terraformer.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Terraformerを使ってAWSのリソースをIaC化する"
-description: "既存のAWSリソースをTerraformerを使ってInfrastructure as Code化する方法を解説したZenn記事です。"
+title: "Migrating AWS Resources to IaC with Terraformer (Japanese)"
+description: "A Zenn article explaining how to convert existing AWS resources into Infrastructure as Code with Terraformer."
 date: "2026-01-31"
 category: "zenn"
 tags: ["Zenn", "AWS", "Terraform", "IaC"]

--- a/content/blog/20260623_speakerdeck-commit-no-naze-wo-yomu.mdx
+++ b/content/blog/20260623_speakerdeck-commit-no-naze-wo-yomu.mdx
@@ -1,8 +1,8 @@
 ---
-title: "コミットの「なぜ」を読む"
-description: "めぐろLT #37「AI×チーム開発、みんなどうしてる？」での発表資料。Entire CLI を使って AI とのセッションを Git に残し、コミットの「なぜ」を読めるようにする取り組みを紹介します。"
+title: "Reading the Why Behind Commits (Japanese)"
+description: "Slides from Meguro LT #37 on AI and team development, introducing an approach to preserving AI sessions in Git with Entire CLI so the reasoning behind commits remains readable."
 date: "2026-06-23"
 category: "speakerdeck"
-tags: ["SpeakerDeck", "AI", "Git", "Claude Code", "チーム開発", "LT"]
+tags: ["SpeakerDeck", "AI", "Git", "Claude Code", "Team Development", "LT"]
 externalUrl: "https://speakerdeck.com/ota1022/komitutono-naze-wodu-mu"
 ---

--- a/src/app/components/AboutMe/page.tsx
+++ b/src/app/components/AboutMe/page.tsx
@@ -14,7 +14,8 @@ const AboutMe: FC = () => {
         <ul style={{ paddingLeft: 20 }}>
           <li>
             <Typography variant="subtitle1">
-              A Software Engineer with 3+ years of experience in developing.
+              A Software Engineer with 3+ years of experience in software
+              development.
             </Typography>
           </li>
           <li>
@@ -26,8 +27,14 @@ const AboutMe: FC = () => {
           </li>
           <li>
             <Typography variant="subtitle1">
-              AWS-certified: Solutions Architect Professional, Security
-              Specialty, etc.
+              AWS certified in Solutions Architect Professional, Security
+              Specialty, and related areas.
+            </Typography>
+          </li>
+          <li>
+            <Typography variant="subtitle1">
+              Named a 2026 Japan AWS Jr. Champion, one of just 114 engineers
+              recognized nationwide by AWS.
             </Typography>
           </li>
         </ul>

--- a/src/app/components/Publication/page.tsx
+++ b/src/app/components/Publication/page.tsx
@@ -8,23 +8,24 @@ const Publication: FC = () => {
       elevation={3}
     >
       <Typography variant="h4" component="h3" sx={{ marginBottom: 2 }}>
-        Publication
+        Publications
       </Typography>
       <Typography variant="body1" component="div" sx={{ marginLeft: 2 }}>
         <ul>
           <li>
-            Improving the Experience of Listening Broadcast Programs Using
-            Social Media Data (Master&rsquo;s thesis){' '}
+            Improving the Listening Experience for Broadcast Programs Using
+            Social Media Data (Japanese), Master&rsquo;s thesis{' '}
             <Link
               href="https://library.naist.jp/opac/en/book/106760"
               target="_blank"
               rel="noopener"
             >
-              [PDF]
+              [Record]
             </Link>
           </li>
           <li>
-            Analysis of the Uniformity Rate of Tweets for Broadcast Programs,
+            Analysis of the Uniformity Rate of Tweets for Broadcast Programs
+            (Japanese),
             The 15th Forum on Data Engineering and Information Management
             (DEIM2023), 4a-3-2, 2023 (2023/3/5, Gifu, Japan){' '}
             <Link
@@ -36,8 +37,9 @@ const Publication: FC = () => {
             </Link>
           </li>
           <li>
-            Proposal of the Radio Programs Compression Method Using Twitter, The
-            14th Forum on Data Engineering and Information Management
+            A Proposal for a Radio Program Compression Method Using Twitter
+            (Japanese), The 14th Forum on Data Engineering and Information
+            Management
             (DEIM2022), C21-2, 2022 (2022/02/28, Online){' '}
             <Link
               href="https://proceedings-of-deim.github.io/DEIM2022/papers/C21-2.pdf"

--- a/src/app/components/Publication/page.tsx
+++ b/src/app/components/Publication/page.tsx
@@ -13,7 +13,7 @@ const Publication: FC = () => {
       <Typography variant="body1" component="div" sx={{ marginLeft: 2 }}>
         <ul>
           <li>
-            Improving the Listening Experience for Broadcast Programs Using
+            Improving the Experience of Listening Broadcast Programs Using
             Social Media Data (Japanese), Master&rsquo;s thesis{' '}
             <Link
               href="https://library.naist.jp/opac/en/book/106760"

--- a/src/app/components/Publication/page.tsx
+++ b/src/app/components/Publication/page.tsx
@@ -18,7 +18,8 @@ const Publication: FC = () => {
             <Link
               href="https://library.naist.jp/opac/en/book/106760"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
+              aria-label="Library record for master's thesis"
             >
               [Record]
             </Link>
@@ -31,7 +32,8 @@ const Publication: FC = () => {
             <Link
               href="https://proceedings-of-deim.github.io/DEIM2023/4a-3-2.pdf"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
+              aria-label="PDF for DEIM2023 paper on tweet uniformity rate for broadcast programs"
             >
               [PDF]
             </Link>
@@ -44,7 +46,8 @@ const Publication: FC = () => {
             <Link
               href="https://proceedings-of-deim.github.io/DEIM2022/papers/C21-2.pdf"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
+              aria-label="PDF for DEIM2022 paper on radio program compression using Twitter"
             >
               [PDF]
             </Link>

--- a/src/components/AboutMe.tsx
+++ b/src/components/AboutMe.tsx
@@ -15,7 +15,8 @@ const AboutMe = (): React.ReactNode => {
         <ul style={{ paddingLeft: 20 }}>
           <li>
             <Typography variant="subtitle1">
-              A Software Engineer with 3+ years of experience in developing.
+              A Software Engineer with 3+ years of experience in software
+              development.
             </Typography>
           </li>
           <li>
@@ -27,8 +28,8 @@ const AboutMe = (): React.ReactNode => {
           </li>
           <li>
             <Typography variant="subtitle1">
-              AWS-certified: Solutions Architect Professional, Security
-              Specialty, etc.
+              AWS certified in Solutions Architect Professional, Security
+              Specialty, and related areas.
             </Typography>
           </li>
           <li>


### PR DESCRIPTION
## Summary
- Translate Japanese blog card metadata into English and mark Japanese-language resources with (Japanese).
- Polish About Me and Publications wording for English readers.
- Keep official Japanese roster/source text where it serves as proof for the AWS Jr. Champion announcement.

## Validation
- git diff --cached --check before commit
- git diff --check before staging
- Japanese text scan reviewed so only intended official proof/source lines remain

## Notes
- AGENTS.md was intentionally left untracked and excluded from this PR.
- npm run lint:biome could not run in this checkout because node_modules is absent and biome is not installed locally.