### PR TITLE
Unify portfolio timeline styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
         "@mui/icons-material": "^5.15.18",
-        "@mui/lab": "^5.0.0-alpha.169",
         "@mui/material": "^5.15.18",
         "@mui/material-nextjs": "^9.3.0",
         "date-fns": "^4.1.0",
@@ -1219,44 +1218,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@floating-ui/core": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
-      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.12"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
-      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.8.0",
-        "@floating-ui/utils": "^0.2.12"
-      }
-    },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
-      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.8.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
-      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
-      "license": "MIT"
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1980,39 +1941,6 @@
         "react": ">=16"
       }
     },
-    "node_modules/@mui/base": {
-      "version": "5.0.0-beta.40-1",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.40-1.tgz",
-      "integrity": "sha512-agKXuNNy0bHUmeU7pNmoZwNFr7Hiyhojkb9+2PVyDG5+6RafYuyMgbrav8CndsB7KUc/U51JAw9vKNDLYBzaUA==",
-      "deprecated": "This package has been replaced by @base-ui/react",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@mui/types": "~7.2.15",
-        "@mui/utils": "^5.17.1",
-        "@popperjs/core": "^2.11.8",
-        "clsx": "^2.1.0",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "5.18.0",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.18.0.tgz",
@@ -2044,47 +1972,6 @@
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/lab": {
-      "version": "5.0.0-alpha.177",
-      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.177.tgz",
-      "integrity": "sha512-bdCxxtNjlWAgN9rtrwlmFydJ1qxA3IIbb6OlomGFsIXw0zGoHomLyjvh72q/R3yUAC0kvSef18cHY1UalLylyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/base": "5.0.0-beta.40-1",
-        "@mui/system": "^5.18.0",
-        "@mui/types": "~7.2.15",
-        "@mui/utils": "^5.17.1",
-        "clsx": "^2.1.0",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@mui/material": ">=5.15.0",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
         "@types/react": {
           "optional": true
         }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@mui/icons-material": "^5.15.18",
-    "@mui/lab": "^5.0.0-alpha.169",
     "@mui/material": "^5.15.18",
     "@mui/material-nextjs": "^9.3.0",
     "date-fns": "^4.1.0",

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -6,13 +6,27 @@ import { Box, IconButton, Link, Tooltip, Typography } from '@mui/material';
 import { useColorScheme } from '@mui/material/styles';
 import NextLink from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useSyncExternalStore } from 'react';
+
+const subscribeToHydration = () => () => {};
+const getClientHydrationSnapshot = () => true;
+const getServerHydrationSnapshot = () => false;
 
 export default function Header() {
   const pathname = usePathname();
   const { mode, systemMode, setMode } = useColorScheme();
+  const isHydrated = useSyncExternalStore(
+    subscribeToHydration,
+    getClientHydrationSnapshot,
+    getServerHydrationSnapshot
+  );
+
   const resolvedMode = mode === 'system' ? systemMode : mode;
-  const isDark = (resolvedMode ?? 'dark') === 'dark';
+  const isDark = isHydrated ? (resolvedMode ?? 'dark') === 'dark' : true;
   const nextMode = isDark ? 'light' : 'dark';
+  const themeToggleLabel = isHydrated
+    ? `Switch to ${nextMode} mode`
+    : 'Toggle color mode';
 
   return (
     <Box
@@ -95,12 +109,12 @@ export default function Header() {
         </Link>
       </Box>
 
-      <Tooltip title={`Switch to ${nextMode} mode`}>
+      <Tooltip title={themeToggleLabel}>
         <IconButton
           sx={{ ml: 1 }}
           onClick={() => setMode(nextMode)}
           color="inherit"
-          aria-label={`Switch to ${nextMode} mode`}
+          aria-label={themeToggleLabel}
         >
           {isDark ? <Brightness7Icon /> : <Brightness4Icon />}
         </IconButton>

--- a/src/components/portfolio/Education.tsx
+++ b/src/components/portfolio/Education.tsx
@@ -1,10 +1,5 @@
-import Timeline from '@mui/lab/Timeline';
-import TimelineConnector from '@mui/lab/TimelineConnector';
-import TimelineContent from '@mui/lab/TimelineContent';
-import TimelineDot from '@mui/lab/TimelineDot';
-import TimelineItem from '@mui/lab/TimelineItem';
-import TimelineSeparator from '@mui/lab/TimelineSeparator';
 import { Box, Link, Paper, Typography } from '@mui/material';
+import { PortfolioTimeline, PortfolioTimelineItem } from './PortfolioTimeline';
 
 export default function Education() {
   return (
@@ -22,15 +17,9 @@ export default function Education() {
       >
         Education
       </Typography>
-      <Timeline
-        sx={{ '& .MuiTimelineItem-root:before': { flex: 0, padding: 0 } }}
-      >
-        <TimelineItem sx={{ '&:before': { display: 'none' } }}>
-          <TimelineSeparator>
-            <TimelineDot color="primary" variant="outlined" />
-            <TimelineConnector />
-          </TimelineSeparator>
-          <TimelineContent sx={{ py: '12px', px: 2 }}>
+      <PortfolioTimeline>
+        <PortfolioTimelineItem>
+          <Box sx={{ py: 1 }}>
             <Typography variant="subtitle2" sx={{ color: 'text.secondary' }}>
               April 2021 - March 2023
             </Typography>
@@ -74,14 +63,10 @@ export default function Education() {
                 <li>Teaching Assistant for Social Computing class</li>
               </ul>
             </Box>
-          </TimelineContent>
-        </TimelineItem>
-        <TimelineItem sx={{ '&:before': { display: 'none' } }}>
-          <TimelineSeparator>
-            <TimelineDot color="secondary" variant="outlined" />
-            <TimelineConnector />
-          </TimelineSeparator>
-          <TimelineContent sx={{ py: '12px', px: 2 }}>
+          </Box>
+        </PortfolioTimelineItem>
+        <PortfolioTimelineItem>
+          <Box sx={{ py: 1 }}>
             <Typography variant="subtitle2" sx={{ color: 'text.secondary' }}>
               April 2017 - March 2021
             </Typography>
@@ -100,9 +85,9 @@ export default function Education() {
                 <li>Studied International Macroeconomics and Econometrics</li>
               </ul>
             </Box>
-          </TimelineContent>
-        </TimelineItem>
-      </Timeline>
+          </Box>
+        </PortfolioTimelineItem>
+      </PortfolioTimeline>
     </Paper>
   );
 }

--- a/src/components/portfolio/Experience.tsx
+++ b/src/components/portfolio/Experience.tsx
@@ -1,10 +1,5 @@
-import Timeline from '@mui/lab/Timeline';
-import TimelineConnector from '@mui/lab/TimelineConnector';
-import TimelineContent from '@mui/lab/TimelineContent';
-import TimelineDot from '@mui/lab/TimelineDot';
-import TimelineItem from '@mui/lab/TimelineItem';
-import TimelineSeparator from '@mui/lab/TimelineSeparator';
 import { Box, Paper, Typography } from '@mui/material';
+import { PortfolioTimeline, PortfolioTimelineItem } from './PortfolioTimeline';
 
 export default function Experience() {
   return (
@@ -22,18 +17,9 @@ export default function Experience() {
       >
         Experience
       </Typography>
-      <Timeline
-        sx={{ '& .MuiTimelineItem-root:before': { flex: 0, padding: 0 } }}
-      >
-        <TimelineItem sx={{ '&:before': { display: 'none' } }}>
-          <TimelineSeparator>
-            <TimelineDot
-              sx={{ bgcolor: 'customColor.main' }}
-              variant="outlined"
-            />
-            <TimelineConnector />
-          </TimelineSeparator>
-          <TimelineContent sx={{ py: '12px', px: 2 }}>
+      <PortfolioTimeline>
+        <PortfolioTimelineItem>
+          <Box sx={{ py: 1 }}>
             <Typography variant="subtitle2" sx={{ color: 'text.secondary' }}>
               January 2025 - Present
             </Typography>
@@ -62,15 +48,11 @@ export default function Experience() {
                 </li>
               </ul>
             </Box>
-          </TimelineContent>
-        </TimelineItem>
+          </Box>
+        </PortfolioTimelineItem>
 
-        <TimelineItem sx={{ '&:before': { display: 'none' } }}>
-          <TimelineSeparator>
-            <TimelineDot color="primary" variant="outlined" />
-            <TimelineConnector />
-          </TimelineSeparator>
-          <TimelineContent sx={{ py: '12px', px: 2 }}>
+        <PortfolioTimelineItem>
+          <Box sx={{ py: 1 }}>
             <Typography variant="subtitle2" sx={{ color: 'text.secondary' }}>
               April 2023 - December 2024
             </Typography>
@@ -98,15 +80,11 @@ export default function Experience() {
                 </li>
               </ul>
             </Box>
-          </TimelineContent>
-        </TimelineItem>
+          </Box>
+        </PortfolioTimelineItem>
 
-        <TimelineItem sx={{ '&:before': { display: 'none' } }}>
-          <TimelineSeparator>
-            <TimelineDot color="secondary" variant="outlined" />
-            <TimelineConnector />
-          </TimelineSeparator>
-          <TimelineContent sx={{ py: '12px', px: 2 }}>
+        <PortfolioTimelineItem>
+          <Box sx={{ py: 1 }}>
             <Typography variant="subtitle2" sx={{ color: 'text.secondary' }}>
               October 2021 - March 2023
             </Typography>
@@ -135,9 +113,9 @@ export default function Experience() {
                 </li>
               </ul>
             </Box>
-          </TimelineContent>
-        </TimelineItem>
-      </Timeline>
+          </Box>
+        </PortfolioTimelineItem>
+      </PortfolioTimeline>
     </Paper>
   );
 }

--- a/src/components/portfolio/PortfolioTimeline.tsx
+++ b/src/components/portfolio/PortfolioTimeline.tsx
@@ -1,0 +1,60 @@
+import { Box } from '@mui/material';
+import type { ReactNode } from 'react';
+
+interface PortfolioTimelineProps {
+  children: ReactNode;
+}
+
+export function PortfolioTimeline({ children }: PortfolioTimelineProps) {
+  return (
+    <Box
+      component="ol"
+      sx={{
+        listStyle: 'none',
+        m: 0,
+        p: 0,
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+export function PortfolioTimelineItem({ children }: PortfolioTimelineProps) {
+  return (
+    <Box
+      component="li"
+      sx={{
+        position: 'relative',
+        pl: { xs: 4, sm: 4.5 },
+        pb: 3,
+        '&:last-of-type': { pb: 0 },
+        '&::before': {
+          content: '""',
+          position: 'absolute',
+          top: 24,
+          bottom: -8,
+          left: 7,
+          width: 2,
+          bgcolor: 'divider',
+        },
+        '&:last-of-type::before': { display: 'none' },
+        '&::after': {
+          content: '""',
+          position: 'absolute',
+          top: 8,
+          left: 0,
+          width: 16,
+          height: 16,
+          boxSizing: 'border-box',
+          border: 3,
+          borderColor: 'primary.main',
+          borderRadius: '50%',
+          bgcolor: 'background.paper',
+        },
+      }}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,24 +1,11 @@
 import { experimental_extendTheme as extendTheme } from '@mui/material/styles';
 
-declare module '@mui/material/styles' {
-  interface Palette {
-    customColor: Palette['primary'];
-  }
-
-  interface PaletteOptions {
-    customColor?: PaletteOptions['primary'];
-  }
-}
-
 const sharedPalette = {
   primary: {
     main: '#4f9cf9',
   },
   secondary: {
     main: '#e85d8e',
-  },
-  customColor: {
-    main: '#ff9800',
   },
 };
 


### PR DESCRIPTION
## Summary

- replace the experimental MUI Lab Timeline with a shared semantic `ol`/`li` component
- use one consistent primary-blue marker color across Experience and Education
- derive marker fill and connector colors from the active light or dark theme
- remove the unused custom orange palette color
- remove `@mui/lab` and its deprecated transitive `@mui/base` dependency
- prevent the saved color mode from causing a theme-button hydration mismatch

## Why

The existing timeline mixed orange, blue, and pink markers without a content-based meaning. It also depended on an experimental MUI Lab component and pulled in the deprecated `@mui/base` package. A small shared CSS timeline provides the same visual structure with fewer dependencies and one predictable color rule.

## Impact

- Experience and Education now use the same marker size, color, spacing, and connector treatment.
- The marker center follows the card background in both color modes.
- The timeline remains responsive without horizontal overflow at 390 px.
- Package installation no longer emits the `@mui/base` deprecation warning.

## Validation

- `npm run lint`
- `npm run lint:eslint`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- browser checks at 1440 px and 390 px in light and dark modes
