### PR TITLE
ブログ目次の階層表示を改善

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { mdxComponents } from '@/components/blog/MDXComponents';
 import PageShell from '@/components/layout/PageShell';
 import { getAllPostSlugs, getPostBySlug, getRelatedPosts } from '@/lib/blog';
 import { formatDateOnly } from '@/lib/date';
-import { extractTableOfContents } from '@/lib/markdown';
+import { extractTableOfContents, groupTableOfContents } from '@/lib/markdown';
 import { Box, Chip, Link, Paper, Typography } from '@mui/material';
 import type { Metadata } from 'next';
 import { MDXRemote } from 'next-mdx-remote/rsc';
@@ -106,6 +106,13 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
   const { frontmatter, content, readingTimeMinutes } = post;
   const formattedDate = formatDateOnly(frontmatter.date);
   const tableOfContents = extractTableOfContents(content);
+  const tableOfContentsSections = groupTableOfContents(tableOfContents);
+  const sectionHeadings = tableOfContents.filter(
+    (heading) => heading.level === 2
+  );
+  const headingsIncludeSectionNumbers =
+    sectionHeadings.length > 0 &&
+    sectionHeadings.every((heading) => /^\d+\.\s+/.test(heading.title));
   const relatedPosts = getRelatedPosts(slug);
   const postUrl = `https://ota1022.github.io/blog/${slug}`;
   const blogPostingJsonLd = {
@@ -209,17 +216,34 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
                 </Typography>
                 <Box
                   component="ol"
-                  sx={{ m: 0, pl: 2.5, maxHeight: 360, overflowY: 'auto' }}
+                  sx={{ m: 0, pl: 3.5, maxHeight: 360, overflowY: 'auto' }}
                 >
-                  {tableOfContents.map((heading) => (
+                  {tableOfContentsSections.map(({ heading, children }) => (
                     <Box
                       component="li"
                       key={`${heading.level}-${heading.id}`}
-                      sx={{ ml: heading.level === 3 ? 2 : 0, py: 0.25 }}
+                      sx={{ py: 0.25, pl: 0.5 }}
                     >
                       <Link href={`#${heading.id}`} underline="hover">
-                        {heading.title}
+                        {headingsIncludeSectionNumbers
+                          ? heading.title.replace(/^\d+\.\s+/, '')
+                          : heading.title}
                       </Link>
+                      {children.length > 0 && (
+                        <Box component="ul" sx={{ mt: 0.25, mb: 0.25, pl: 3 }}>
+                          {children.map((child) => (
+                            <Box
+                              component="li"
+                              key={`${child.level}-${child.id}`}
+                              sx={{ py: 0.25, pl: 0.25 }}
+                            >
+                              <Link href={`#${child.id}`} underline="hover">
+                                {child.title}
+                              </Link>
+                            </Box>
+                          ))}
+                        </Box>
+                      )}
                     </Box>
                   ))}
                 </Box>

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -4,6 +4,11 @@ export interface TableOfContentsItem {
   level: 2 | 3;
 }
 
+export interface TableOfContentsSection {
+  heading: TableOfContentsItem;
+  children: TableOfContentsItem[];
+}
+
 /**
  * Creates stable anchor IDs shared by the MDX renderer and table of contents.
  */
@@ -40,6 +45,24 @@ export function extractTableOfContents(content: string): TableOfContentsItem[] {
   }
 
   return headings;
+}
+
+export function groupTableOfContents(
+  headings: TableOfContentsItem[]
+): TableOfContentsSection[] {
+  const sections: TableOfContentsSection[] = [];
+
+  for (const heading of headings) {
+    const currentSection = sections.at(-1);
+    if (heading.level === 2 || !currentSection) {
+      sections.push({ heading, children: [] });
+      continue;
+    }
+
+    currentSection.children.push(heading);
+  }
+
+  return sections;
 }
 
 export function calculateReadingTime(content: string): number {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": false,
+    "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,


### PR DESCRIPTION
## 変更内容

- 記事の目次で見出し2を親項目、見出し3を子項目として表示する
- 見出し2がすべて番号付きの場合、目次上の重複する番号を除去する
- Next.jsの生成設定に合わせてJavaScriptファイルの読み込みを許可する

## 背景

従来の目次は見出し2と見出し3を同じ階層の連番として表示していたため、記事構造を把握しにくかった。また、番号付き見出しではリスト番号と見出し内の番号が重複していた。

## 影響

ブログ記事の目次表示のみを変更する。本文の見出しとアンカーは変更しない。

## 検証

- `npm run check`
- `npm run build`
