### PR TITLE
Fix light mode flash before dark mode applies

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,15 @@
 import '@/styles/globals.css';
+import InitColorSchemeScript from '@mui/material/InitColorSchemeScript';
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import Script from 'next/script';
 import type { ReactNode } from 'react';
 import ClientProviders from './providers';
+import {
+  COLOR_SCHEME_ATTRIBUTE,
+  DEFAULT_MODE,
+  MODE_STORAGE_KEY,
+} from './theme-config';
 
 const inconsolata = localFont({
   src: '../assets/fonts/Inconsolata-Regular.ttf',
@@ -87,6 +93,11 @@ export default function RootLayout({
         />
       </head>
       <body className={inconsolata.variable}>
+        <InitColorSchemeScript
+          attribute={COLOR_SCHEME_ATTRIBUTE}
+          modeStorageKey={MODE_STORAGE_KEY}
+          defaultMode={DEFAULT_MODE}
+        />
         <ClientProviders>{children}</ClientProviders>
       </body>
     </html>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -5,6 +5,11 @@ import { Experimental_CssVarsProvider } from '@mui/material/styles';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v16-appRouter';
 import type { ReactNode } from 'react';
 import theme from '@/theme/theme';
+import {
+  COLOR_SCHEME_ATTRIBUTE,
+  DEFAULT_MODE,
+  MODE_STORAGE_KEY,
+} from './theme-config';
 
 export default function ClientProviders({
   children,
@@ -15,8 +20,9 @@ export default function ClientProviders({
     <AppRouterCacheProvider>
       <Experimental_CssVarsProvider
         theme={theme}
-        defaultMode="system"
-        modeStorageKey="themeMode"
+        defaultMode={DEFAULT_MODE}
+        modeStorageKey={MODE_STORAGE_KEY}
+        attribute={COLOR_SCHEME_ATTRIBUTE}
         disableTransitionOnChange
       >
         <CssBaseline />

--- a/src/app/theme-config.ts
+++ b/src/app/theme-config.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared between the render-blocking color scheme script in `layout.tsx` and
+ * the MUI CSS vars provider in `providers.tsx`. Both must agree, otherwise the
+ * pre-hydration script would apply a different scheme than the provider.
+ */
+export const MODE_STORAGE_KEY = 'themeMode';
+export const COLOR_SCHEME_ATTRIBUTE = 'data-mui-color-scheme';
+export const DEFAULT_MODE = 'system';

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -6,12 +6,34 @@ html {
   scroll-behavior: smooth;
 }
 
+/*
+ * The canvas is painted before MUI's CSS variables are available, so the
+ * background is duplicated here to avoid a light flash on first paint.
+ * Keep these values in sync with `palette.background.default` in
+ * `src/theme/theme.ts`.
+ *
+ * `data-mui-color-scheme` is set by the render-blocking InitColorSchemeScript;
+ * the media query is the fallback for the moment before it runs.
+ */
+html {
+  color-scheme: light dark;
+  background-color: #f5f5f5;
+}
+
+@media (prefers-color-scheme: dark) {
+  html {
+    background-color: #121212;
+  }
+}
+
 html[data-mui-color-scheme="light"] {
   color-scheme: light;
+  background-color: #f5f5f5;
 }
 
 html[data-mui-color-scheme="dark"] {
   color-scheme: dark;
+  background-color: #121212;
 }
 
 html,


### PR DESCRIPTION
The static export prerenders HTML without a color scheme attribute, so the
first paint used the light palette until the CSS vars provider hydrated and
switched to dark.

Render MUI's InitColorSchemeScript as the first element in <body> so the
`data-mui-color-scheme` attribute is set from localStorage / the OS
preference before paint. The light and dark variable blocks are already
inlined in <head>, so the correct palette applies on the very first frame.

Also paint the html canvas explicitly (defaulting via prefers-color-scheme)
so the browser background matches before any variables resolve, and share
the storage key, attribute and default mode between the script and the
provider so the two can't drift apart.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01F8g7X5WNt1JjssqfHfYPX1