### PR TITLE
CI/CDの実行時間を短縮

### DIFF
--- a/.github/actions/build-site/action.yml
+++ b/.github/actions/build-site/action.yml
@@ -1,0 +1,92 @@
+name: Build site
+description: Install dependencies, run the checks, and produce the static export in ./out.
+
+outputs:
+  cv-available:
+    description: Whether a public CV source is present in the repository.
+    value: ${{ steps.cv_source.outputs.available }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@v5
+      with:
+        node-version: "22"
+        cache: 'npm'
+
+    - name: Install dependencies
+      shell: bash
+      run: npm ci --prefer-offline --no-audit --no-fund
+
+    # Fail fast on cheap checks before spending time on the CV toolchain.
+    - name: Lint
+      shell: bash
+      run: npm run lint
+
+    - name: Type check
+      shell: bash
+      run: npm run typecheck
+
+    - name: Detect public CV source
+      id: cv_source
+      shell: bash
+      run: |
+        if [[ -f content/cv/resume.en.md ]]; then
+          echo "available=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          echo "Public CV source is not present; keeping the checked-in public/cv.pdf."
+        fi
+
+    # Installing the TeX Live toolchain takes over a minute, so the rendered
+    # PDF is cached against its inputs and only rebuilt when they change.
+    - name: Restore generated CV PDF
+      id: cv_cache
+      if: steps.cv_source.outputs.available == 'true'
+      uses: actions/cache/restore@v4
+      with:
+        path: public/cv.pdf
+        key: cv-pdf-v1-${{ hashFiles('content/cv/**', 'scripts/generate-cv.sh') }}
+
+    - name: Install CV build dependencies
+      if: steps.cv_source.outputs.available == 'true' && steps.cv_cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          lmodern \
+          pandoc \
+          poppler-utils \
+          texlive-fonts-recommended \
+          texlive-latex-extra \
+          texlive-latex-recommended \
+          texlive-xetex
+
+    - name: Generate public CV PDF
+      if: steps.cv_source.outputs.available == 'true' && steps.cv_cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: bash scripts/generate-cv.sh
+
+    # Only reached when generation succeeded, so a failed build cannot store
+    # a stale PDF under the current input hash.
+    - name: Save generated CV PDF
+      if: steps.cv_source.outputs.available == 'true' && steps.cv_cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: public/cv.pdf
+        key: cv-pdf-v1-${{ hashFiles('content/cv/**', 'scripts/generate-cv.sh') }}
+
+    - name: Restore Next.js build cache
+      uses: actions/cache@v4
+      with:
+        path: .next/cache
+        key: nextjs-${{ hashFiles('package-lock.json') }}-${{ hashFiles('src/**', 'content/**', 'next.config.mjs') }}
+        restore-keys: |
+          nextjs-${{ hashFiles('package-lock.json') }}-
+
+    - name: Build and Static HTML export with Next.js
+      shell: bash
+      run: npm run build

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -3,8 +3,16 @@ name: Deploy Next.js site to Pages
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - 'README.md'
+      - 'CLAUDE.md'
+      - 'AGENTS.md'
   pull_request:
     branches: ["main"]
+    paths-ignore:
+      - 'README.md'
+      - 'CLAUDE.md'
+      - 'AGENTS.md'
   workflow_dispatch:
 
 permissions:
@@ -15,85 +23,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Pull requests only verify the build. They deliberately avoid the
+  # github-pages environment, which would record a deployment and can be
+  # rejected outright by the environment's branch protection rules.
   build:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Setup Node
-        uses: actions/setup-node@v5
-        with:
-          node-version: "22"
-          cache: 'npm'
-
-      - name: Setup Pages
-        if: github.event_name != 'pull_request'
-        uses: actions/configure-pages@v5
-        with:
-          static_site_generator: next
-
-      - name: Install dependencies
-        run: npm ci --prefer-offline --no-audit --no-fund
-
-      # Fail fast on cheap checks before spending time on the CV toolchain.
-      - name: Lint
-        run: npm run lint
-
-      - name: Type check
-        run: npm run typecheck
-
-      - name: Detect public CV source
-        id: cv_source
-        shell: bash
-        run: |
-          if [[ -f content/cv/resume.en.md ]]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "Public CV source is not present; keeping the checked-in public/cv.pdf."
-          fi
-
-      # Installing the TeX Live toolchain takes over a minute, so the rendered
-      # PDF is cached against its inputs and only rebuilt when they change.
-      - name: Restore generated CV PDF
-        id: cv_cache
-        if: steps.cv_source.outputs.available == 'true'
-        uses: actions/cache/restore@v4
-        with:
-          path: public/cv.pdf
-          key: cv-pdf-v1-${{ hashFiles('content/cv/**', 'scripts/generate-cv.sh') }}
-
-      - name: Install CV build dependencies
-        if: steps.cv_source.outputs.available == 'true' && steps.cv_cache.outputs.cache-hit != 'true'
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            lmodern \
-            pandoc \
-            poppler-utils \
-            texlive-fonts-recommended \
-            texlive-latex-extra \
-            texlive-latex-recommended \
-            texlive-xetex
-
-      - name: Generate public CV PDF
-        if: steps.cv_source.outputs.available == 'true' && steps.cv_cache.outputs.cache-hit != 'true'
-        run: bash scripts/generate-cv.sh
-
-      # Only reached when generation succeeded, so a failed build cannot store
-      # a stale PDF under the current input hash.
-      - name: Save generated CV PDF
-        if: steps.cv_source.outputs.available == 'true' && steps.cv_cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: public/cv.pdf
-          key: cv-pdf-v1-${{ hashFiles('content/cv/**', 'scripts/generate-cv.sh') }}
+      - name: Build site
+        id: site
+        uses: ./.github/actions/build-site
 
       - name: Upload CV preview
-        if: github.event_name == 'pull_request' && steps.cv_source.outputs.available == 'true'
+        if: steps.site.outputs.cv-available == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: cv-preview
@@ -101,34 +46,35 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      - name: Restore Next.js build cache
-        uses: actions/cache@v4
-        with:
-          path: .next/cache
-          key: nextjs-${{ hashFiles('package-lock.json') }}-${{ hashFiles('src/**', 'content/**', 'next.config.mjs') }}
-          restore-keys: |
-            nextjs-${{ hashFiles('package-lock.json') }}-
-
-      - name: Build and Static HTML export with Next.js
-        run: npm run build
-
-      - name: Upload artifact
-        if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./out
-
+  # Build and deploy share a runner: a separate deploy job spent more time
+  # waiting for a runner than deploying.
   deploy:
     if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
     permissions:
+      contents: read
       pages: write
       id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+        with:
+          static_site_generator: next
+
+      - name: Build site
+        uses: ./.github/actions/build-site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: "22"
           cache: 'npm'
 
       - name: Setup Pages
@@ -34,7 +34,14 @@ jobs:
           static_site_generator: next
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --prefer-offline --no-audit --no-fund
+
+      # Fail fast on cheap checks before spending time on the CV toolchain.
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npm run typecheck
 
       - name: Detect public CV source
         id: cv_source
@@ -47,8 +54,20 @@ jobs:
             echo "Public CV source is not present; keeping the checked-in public/cv.pdf."
           fi
 
-      - name: Install CV build dependencies
+      # Installing the TeX Live toolchain takes over a minute, so the rendered
+      # PDF is cached against its inputs and only rebuilt when they change.
+      - name: Restore generated CV PDF
+        id: cv_cache
         if: steps.cv_source.outputs.available == 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: public/cv.pdf
+          key: cv-pdf-v1-${{ hashFiles('content/cv/**', 'scripts/generate-cv.sh') }}
+
+      - name: Install CV build dependencies
+        if: steps.cv_source.outputs.available == 'true' && steps.cv_cache.outputs.cache-hit != 'true'
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -61,8 +80,17 @@ jobs:
             texlive-xetex
 
       - name: Generate public CV PDF
-        if: steps.cv_source.outputs.available == 'true'
+        if: steps.cv_source.outputs.available == 'true' && steps.cv_cache.outputs.cache-hit != 'true'
         run: bash scripts/generate-cv.sh
+
+      # Only reached when generation succeeded, so a failed build cannot store
+      # a stale PDF under the current input hash.
+      - name: Save generated CV PDF
+        if: steps.cv_source.outputs.available == 'true' && steps.cv_cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: public/cv.pdf
+          key: cv-pdf-v1-${{ hashFiles('content/cv/**', 'scripts/generate-cv.sh') }}
 
       - name: Upload CV preview
         if: github.event_name == 'pull_request' && steps.cv_source.outputs.available == 'true'
@@ -73,11 +101,13 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      - name: Lint
-        run: npm run lint
-
-      - name: Type check
-        run: npm run typecheck
+      - name: Restore Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: nextjs-${{ hashFiles('package-lock.json') }}-${{ hashFiles('src/**', 'content/**', 'next.config.mjs') }}
+          restore-keys: |
+            nextjs-${{ hashFiles('package-lock.json') }}-
 
       - name: Build and Static HTML export with Next.js
         run: npm run build


### PR DESCRIPTION
## 概要

Pagesワークフローの実行時間が155秒かかっており、その大半が毎回同じ成果物を作り直す時間だったため、入力が変わったときだけ再生成するように変更する。

## 背景

直近のラン（125秒のbuildジョブ）の内訳は以下のとおり。

| ステップ | 時間 |
|---|---|
| Set up job / Checkout / Setup Node / Pages | 12s |
| `npm ci` | 12s |
| **Install CV build dependencies（TeX Liveのapt install）** | **73s** |
| Generate CV PDF | 2s |
| Lint | 0s |
| Type check | 4s |
| Build | 17s |
| Upload artifact | 1s |

CVの原本 `content/cv/resume.en.md` は数コミット前から変わっていないが、毎回TeX Liveを導入して同じPDFを生成していた。またビルドログに `No build cache found` が出ており、Next.jsも毎回フルビルドしていた。deployジョブは実処理8秒に対しランナー確保だけで12秒かかっていた。

CV導入以前のランも64〜129秒（多くは90秒前後）で、固定費以外にも削減余地があった。

## 変更内容

- CVのPDFを `content/cv/**` と `scripts/generate-cv.sh` のハッシュをキーにキャッシュし、ヒット時はapt installとpandocを両方スキップする。restoreとsaveを分離し、生成が失敗したジョブが古いPDFを新しい入力ハッシュで保存しないようにした
- `.next/cache` を永続化する
- LintとType checkをCVのステップより前に移動し、遅い処理の前に失敗させる
- buildとdeployを同一ランナーで実行する。Pull Requestは別ジョブのまま残した。`environment: github-pages` はジョブに宣言した時点でデプロイが記録され、環境のブランチ保護によっては拒否されるため。共通のビルド手順は composite action `.github/actions/build-site` に切り出して二重管理を避けた
- リポジトリのドキュメントのみの変更ではワークフローを実行しない
- `npm ci` に `--prefer-offline --no-audit --no-fund` を追加
- `actions/checkout@v5`、`actions/setup-node@v5`、Node 22に更新（Node 20の非推奨警告も解消される）

## 影響

キャッシュが有効な状態で、buildとdeployを合わせて155秒から45〜50秒程度になる見込み。`main` での初回ランはキャッシュ生成のため従来どおりの時間がかかる。

ジョブ名は `build` / `deploy` のまま変更していないため、required status checkの参照先は変わらない。

`paths-ignore` により、`README.md` / `CLAUDE.md` / `AGENTS.md` のみを変更したPull Requestではワークフローが実行されない。`build` をrequired status checkに設定している場合、該当のPull Requestはマージできなくなる点に注意。

## 確認

- `npm run lint`
- `npm run typecheck`
- `npm run build`（Node 22で成功）
- `.next/cache` 有無でのビルド時間を比較し、17.8秒から7.7秒（コンパイルは6.8秒から0.26秒）になることを確認した
- `actionlint` で警告がないことを確認した

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPg5ciSNvMPsprxFFau8TT)_