### PR TITLE
Flatten the blog post page, align content width, and stick the header

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -5,7 +5,9 @@ import PageShell from '@/components/layout/PageShell';
 import { getAllPostSlugs, getPostBySlug, getRelatedPosts } from '@/lib/blog';
 import { formatDateOnly } from '@/lib/date';
 import { extractTableOfContents, groupTableOfContents } from '@/lib/markdown';
-import { Box, Chip, Link, Paper, Typography } from '@mui/material';
+import { SITE_AUTHOR, SITE_URL } from '@/lib/site';
+import { CONTENT_MAX_WIDTH } from '@/theme/layout';
+import { Box, Chip, Link, Typography } from '@mui/material';
 import type { Metadata } from 'next';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 import { notFound } from 'next/navigation';
@@ -83,7 +85,10 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
     if (!hasAnyPosts && slug === PLACEHOLDER_SLUG) {
       return (
         <PageShell>
-          <Box component="main" sx={{ my: 4 }}>
+          <Box
+            component="main"
+            sx={{ mx: 'auto', my: 4, maxWidth: CONTENT_MAX_WIDTH }}
+          >
             <Link
               href="/blog"
               underline="hover"
@@ -115,10 +120,8 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
     sectionHeadings.length > 0 &&
     sectionHeadings.every((heading) => /^\d+\.\s+/.test(heading.title));
   const relatedPosts = getRelatedPosts(slug);
-  const postUrl = `https://ota1022.github.io/blog/${slug}`;
-  const socialImageUrl = `https://ota1022.github.io${
-    frontmatter.ogImage ?? `/og/${slug}.png`
-  }`;
+  const postUrl = `${SITE_URL}/blog/${slug}`;
+  const socialImageUrl = `${SITE_URL}${frontmatter.ogImage ?? `/og/${slug}.png`}`;
   const blogPostingJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'BlogPosting',
@@ -128,16 +131,9 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
     mainEntityOfPage: postUrl,
     url: postUrl,
     image: socialImageUrl,
-    author: {
-      '@type': 'Person',
-      name: 'Itaru OTA',
-      url: 'https://ota1022.github.io',
-    },
-    publisher: {
-      '@type': 'Person',
-      name: 'Itaru OTA',
-      url: 'https://ota1022.github.io',
-    },
+    isPartOf: { '@type': 'Blog', '@id': `${SITE_URL}/blog` },
+    author: SITE_AUTHOR,
+    publisher: SITE_AUTHOR,
     keywords: frontmatter.tags?.join(', '),
   };
 
@@ -150,7 +146,10 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
         }}
       />
       <PageShell>
-        <Box component="main" sx={{ my: 4 }}>
+        <Box
+          component="main"
+          sx={{ mx: 'auto', my: 4, maxWidth: CONTENT_MAX_WIDTH }}
+        >
           <Link
             href="/blog"
             underline="hover"
@@ -159,11 +158,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
             ← Back to Blog
           </Link>
 
-          <Paper
-            component="article"
-            elevation={2}
-            sx={{ p: { xs: 2, sm: 3, md: 4 }, mt: 2 }}
-          >
+          <Box component="article" sx={{ mt: 2 }}>
             <Box sx={{ mb: 3 }}>
               <BlogCategoryChip
                 category={frontmatter.category}
@@ -278,7 +273,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
                 }}
               />
             </Box>
-          </Paper>
+          </Box>
 
           {relatedPosts.length > 0 && (
             <Box
@@ -294,13 +289,15 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
               >
                 Related writing &amp; talks
               </Typography>
-              {relatedPosts.map((relatedPost) => (
-                <BlogCard
-                  key={relatedPost.slug}
-                  post={relatedPost}
-                  headingLevel="h3"
-                />
-              ))}
+              <Box component="ul" sx={{ listStyle: 'none', m: 0, p: 0 }}>
+                {relatedPosts.map((relatedPost) => (
+                  <BlogCard
+                    key={relatedPost.slug}
+                    post={relatedPost}
+                    headingLevel="h3"
+                  />
+                ))}
+              </Box>
             </Box>
           )}
         </Box>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,18 +1,21 @@
 import BlogList from '@/components/blog/BlogList';
 import PageShell from '@/components/layout/PageShell';
 import { getAllPosts } from '@/lib/blog';
+import { SITE_AUTHOR, SITE_URL } from '@/lib/site';
+import { CONTENT_MAX_WIDTH } from '@/theme/layout';
 import { Box } from '@mui/material';
 import type { Metadata } from 'next';
 
+const BLOG_DESCRIPTION =
+  'Technical articles, talks, and professional updates in English by Itaru OTA.';
+
 export const metadata: Metadata = {
   title: 'Blog',
-  description:
-    'Technical articles, talks, and professional updates in English by Itaru OTA.',
+  description: BLOG_DESCRIPTION,
   alternates: { canonical: '/blog' },
   openGraph: {
     title: 'Blog | Itaru OTA',
-    description:
-      'Technical articles, talks, and professional updates in English by Itaru OTA.',
+    description: BLOG_DESCRIPTION,
     url: '/blog',
     images: [{ url: '/og/default.png', width: 1200, height: 630 }],
   },
@@ -21,11 +24,43 @@ export const metadata: Metadata = {
 export default function BlogPage() {
   const allPosts = getAllPosts();
 
+  const blogJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Blog',
+    '@id': `${SITE_URL}/blog`,
+    url: `${SITE_URL}/blog`,
+    name: 'Blog | Itaru OTA',
+    description: BLOG_DESCRIPTION,
+    inLanguage: 'en',
+    author: SITE_AUTHOR,
+    publisher: SITE_AUTHOR,
+    blogPost: allPosts.map((post) => ({
+      '@type': 'BlogPosting',
+      headline: post.frontmatter.title,
+      description: post.frontmatter.description,
+      datePublished: post.frontmatter.date,
+      url: post.frontmatter.externalUrl ?? `${SITE_URL}/blog/${post.slug}`,
+      keywords: post.frontmatter.tags?.join(', '),
+      author: SITE_AUTHOR,
+    })),
+  };
+
   return (
-    <PageShell>
-      <Box component="main" sx={{ my: 4 }}>
-        <BlogList initialPosts={allPosts} />
-      </Box>
-    </PageShell>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(blogJsonLd).replace(/</g, '\\u003c'),
+        }}
+      />
+      <PageShell>
+        <Box
+          component="main"
+          sx={{ mx: 'auto', my: 4, maxWidth: CONTENT_MAX_WIDTH }}
+        >
+          <BlogList initialPosts={allPosts} />
+        </Box>
+      </PageShell>
+    </>
   );
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,3 +1,4 @@
+import { SITE_URL } from '@/lib/site';
 import type { MetadataRoute } from 'next';
 
 export const dynamic = 'force-static';
@@ -8,7 +9,7 @@ export default function robots(): MetadataRoute.Robots {
       userAgent: '*',
       allow: '/',
     },
-    sitemap: 'https://ota1022.github.io/sitemap.xml',
-    host: 'https://ota1022.github.io',
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,9 +1,8 @@
 import { getAllPosts } from '@/lib/blog';
+import { SITE_URL } from '@/lib/site';
 import type { MetadataRoute } from 'next';
 
 export const dynamic = 'force-static';
-
-const SITE_URL = 'https://ota1022.github.io';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const posts = getAllPosts()

--- a/src/components/blog/BlogCard.tsx
+++ b/src/components/blog/BlogCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import type { BlogPostMetadata } from '@/types/blog';
 import { formatDateOnly } from '@/lib/date';
+import type { BlogPostMetadata } from '@/types/blog';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { Box, Card, CardContent, Chip, Link, Typography } from '@mui/material';
 import NextLink from 'next/link';
@@ -20,75 +20,101 @@ export default function BlogCard({ post, headingLevel = 'h2' }: BlogCardProps) {
   const isExternal = !!frontmatter.externalUrl;
 
   return (
-    <Link
-      component={isExternal ? 'a' : NextLink}
-      href={href}
-      target={isExternal ? '_blank' : undefined}
-      rel={isExternal ? 'noopener noreferrer' : undefined}
-      aria-label={
-        isExternal
-          ? `${frontmatter.title}, opens in a new tab`
-          : frontmatter.title
-      }
-      underline="none"
-      color="inherit"
-      display="block"
-      sx={{ mb: 2.5 }}
-    >
+    <Box component="li" sx={{ mb: 2.5, '&:last-of-type': { mb: 0 } }}>
       <Card
         sx={{
+          position: 'relative',
           transition:
             'transform 180ms ease, border-color 180ms ease, background-color 180ms ease',
           '&:hover': {
             transform: 'translateY(-2px)',
             borderColor: 'primary.main',
           },
+          '&:focus-within': {
+            borderColor: 'primary.main',
+            outline: '2px solid',
+            outlineColor: 'primary.main',
+            outlineOffset: 2,
+          },
           '@media (prefers-reduced-motion: reduce)': {
             '&:hover': { transform: 'none' },
           },
-          cursor: 'pointer',
         }}
       >
         <CardContent>
-          <Box sx={{ mb: 1 }}>
-            <BlogCategoryChip category={frontmatter.category} />
-            <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+              gap: 1,
+              mb: 1,
+            }}
+          >
+            <BlogCategoryChip
+              category={frontmatter.category}
+              marginBottom={0}
+            />
+            <Typography
+              component="time"
+              dateTime={frontmatter.date}
+              variant="caption"
+              color="text.secondary"
+            >
               {formattedDate}
             </Typography>
             {post.readingTimeMinutes && (
-              <Typography
-                variant="caption"
-                color="text.secondary"
-                sx={{ ml: 1 }}
-              >
+              <Typography variant="caption" color="text.secondary">
                 · {post.readingTimeMinutes} min read
               </Typography>
             )}
           </Box>
 
-          <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
-            <Typography
-              variant="h5"
-              component={headingLevel}
-              gutterBottom
-              sx={{ mb: 1, flex: 1 }}
+          <Typography variant="h5" component={headingLevel} sx={{ mb: 1 }}>
+            <Link
+              component={isExternal ? 'a' : NextLink}
+              href={href}
+              target={isExternal ? '_blank' : undefined}
+              rel={isExternal ? 'noopener noreferrer' : undefined}
+              aria-label={
+                isExternal
+                  ? `${frontmatter.title}, opens in a new tab`
+                  : undefined
+              }
+              underline="hover"
+              color="inherit"
+              // Stretch the anchor across the card so the whole card stays
+              // clickable while the link text stays limited to the title.
+              sx={{
+                '&::after': {
+                  content: '""',
+                  position: 'absolute',
+                  inset: 0,
+                },
+                '&:focus-visible': { outline: 'none' },
+              }}
             >
               {frontmatter.title}
-            </Typography>
-            {isExternal && (
-              <OpenInNewIcon
-                aria-hidden="true"
-                sx={{ mt: 0.5, fontSize: 18, color: 'text.secondary' }}
-              />
-            )}
-          </Box>
+              {isExternal && (
+                <OpenInNewIcon
+                  aria-hidden="true"
+                  sx={{
+                    ml: 0.75,
+                    fontSize: '0.7em',
+                    verticalAlign: 'middle',
+                    color: 'text.secondary',
+                  }}
+                />
+              )}
+            </Link>
+          </Typography>
 
-          <Typography variant="body2" color="text.secondary" paragraph>
+          <Typography variant="body2" color="text.secondary">
             {frontmatter.description}
           </Typography>
 
           {frontmatter.tags && frontmatter.tags.length > 0 && (
-            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1 }}>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1.5 }}>
               {frontmatter.tags.map((tag) => (
                 <Chip
                   key={tag}
@@ -102,6 +128,6 @@ export default function BlogCard({ post, headingLevel = 'h2' }: BlogCardProps) {
           )}
         </CardContent>
       </Card>
-    </Link>
+    </Box>
   );
 }

--- a/src/components/blog/BlogList.tsx
+++ b/src/components/blog/BlogList.tsx
@@ -68,7 +68,7 @@ export default function BlogList({ initialPosts }: BlogListProps) {
           No entries found.
         </Typography>
       ) : (
-        <Box>
+        <Box component="ul" sx={{ listStyle: 'none', m: 0, p: 0 }}>
           {filteredPosts.map((post) => (
             <BlogCard key={post.slug} post={post} />
           ))}

--- a/src/components/blog/MDXComponents.tsx
+++ b/src/components/blog/MDXComponents.tsx
@@ -12,6 +12,7 @@ import {
 import type { MDXComponents } from 'mdx/types';
 import type { ReactNode } from 'react';
 import { slugifyHeading } from '@/lib/markdown';
+import { ANCHOR_SCROLL_MARGIN } from '@/theme/layout';
 import { CodeBlock } from './CodeBlock';
 import { GitHubRepoCard } from './GitHubRepoCard';
 
@@ -71,7 +72,7 @@ export const mdxComponents: MDXComponents = {
       variant="h3"
       component="h2"
       gutterBottom
-      sx={{ mt: 4, mb: 2, scrollMarginTop: 24 }}
+      sx={{ mt: 4, mb: 2, scrollMarginTop: ANCHOR_SCROLL_MARGIN }}
     >
       {children}
     </Typography>
@@ -88,7 +89,7 @@ export const mdxComponents: MDXComponents = {
         pb: 1,
         borderBottom: 1,
         borderColor: 'grey.600',
-        scrollMarginTop: 24,
+        scrollMarginTop: ANCHOR_SCROLL_MARGIN,
       }}
     >
       {children}
@@ -100,7 +101,7 @@ export const mdxComponents: MDXComponents = {
       variant="h5"
       component="h3"
       gutterBottom
-      sx={{ mt: 2, mb: 1, scrollMarginTop: 24 }}
+      sx={{ mt: 2, mb: 1, scrollMarginTop: ANCHOR_SCROLL_MARGIN }}
     >
       {children}
     </Typography>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -32,11 +32,14 @@ export default function Header() {
     <Box
       component="header"
       sx={{
+        position: 'sticky',
+        top: 0,
+        zIndex: (theme) => theme.zIndex.appBar,
         display: 'flex',
         width: '100%',
         alignItems: 'center',
         justifyContent: 'space-between',
-        bgcolor: 'transparent',
+        bgcolor: 'background.default',
         color: 'text.primary',
         borderBottom: 1,
         borderColor: 'divider',

--- a/src/components/portfolio/AboutMe.tsx
+++ b/src/components/portfolio/AboutMe.tsx
@@ -1,3 +1,4 @@
+import { CONTENT_MAX_WIDTH } from '@/theme/layout';
 import { Paper, Typography } from '@mui/material';
 
 export default function AboutMe() {
@@ -11,7 +12,7 @@ export default function AboutMe() {
         my: { xs: 3, sm: 4 },
         px: { xs: 0.5, sm: 1 },
         py: { xs: 3, sm: 4 },
-        maxWidth: 600,
+        maxWidth: CONTENT_MAX_WIDTH,
         overflow: 'hidden',
         bgcolor: 'transparent',
         border: 0,

--- a/src/components/portfolio/Awards.tsx
+++ b/src/components/portfolio/Awards.tsx
@@ -1,3 +1,4 @@
+import { CONTENT_MAX_WIDTH } from '@/theme/layout';
 import { Link, Paper, Typography } from '@mui/material';
 
 export default function Awards() {
@@ -11,7 +12,7 @@ export default function Awards() {
         my: { xs: 3, sm: 4 },
         px: { xs: 0.5, sm: 1 },
         py: { xs: 3, sm: 4 },
-        maxWidth: 600,
+        maxWidth: CONTENT_MAX_WIDTH,
         overflow: 'hidden',
         bgcolor: 'transparent',
         border: 0,

--- a/src/components/portfolio/Certifications.tsx
+++ b/src/components/portfolio/Certifications.tsx
@@ -1,3 +1,4 @@
+import { CONTENT_MAX_WIDTH } from '@/theme/layout';
 import { Box, Link, Paper, Typography } from '@mui/material';
 
 export default function Certifications() {
@@ -11,7 +12,7 @@ export default function Certifications() {
         my: { xs: 3, sm: 4 },
         px: { xs: 0.5, sm: 1 },
         py: { xs: 3, sm: 4 },
-        maxWidth: 600,
+        maxWidth: CONTENT_MAX_WIDTH,
         overflow: 'hidden',
         bgcolor: 'transparent',
         border: 0,

--- a/src/components/portfolio/Education.tsx
+++ b/src/components/portfolio/Education.tsx
@@ -1,3 +1,4 @@
+import { CONTENT_MAX_WIDTH } from '@/theme/layout';
 import { Box, Link, Paper, Typography } from '@mui/material';
 import { PortfolioTimeline, PortfolioTimelineItem } from './PortfolioTimeline';
 
@@ -12,7 +13,7 @@ export default function Education() {
         my: { xs: 3, sm: 4 },
         px: { xs: 0.5, sm: 1 },
         py: { xs: 3, sm: 4 },
-        maxWidth: 600,
+        maxWidth: CONTENT_MAX_WIDTH,
         overflow: 'hidden',
         bgcolor: 'transparent',
         border: 0,

--- a/src/components/portfolio/Experience.tsx
+++ b/src/components/portfolio/Experience.tsx
@@ -1,3 +1,4 @@
+import { CONTENT_MAX_WIDTH } from '@/theme/layout';
 import { Box, Paper, Typography } from '@mui/material';
 import { PortfolioTimeline, PortfolioTimelineItem } from './PortfolioTimeline';
 
@@ -12,7 +13,7 @@ export default function Experience() {
         my: { xs: 3, sm: 4 },
         px: { xs: 0.5, sm: 1 },
         py: { xs: 3, sm: 4 },
-        maxWidth: 600,
+        maxWidth: CONTENT_MAX_WIDTH,
         overflow: 'hidden',
         bgcolor: 'transparent',
         border: 0,

--- a/src/components/portfolio/Publications.tsx
+++ b/src/components/portfolio/Publications.tsx
@@ -1,3 +1,4 @@
+import { CONTENT_MAX_WIDTH } from '@/theme/layout';
 import { Link, Paper, Typography } from '@mui/material';
 
 export default function Publications() {
@@ -11,7 +12,7 @@ export default function Publications() {
         my: { xs: 3, sm: 4 },
         px: { xs: 0.5, sm: 1 },
         py: { xs: 3, sm: 4 },
-        maxWidth: 600,
+        maxWidth: CONTENT_MAX_WIDTH,
         overflow: 'hidden',
         bgcolor: 'transparent',
         border: 0,

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,7 @@
+export const SITE_URL = 'https://ota1022.github.io';
+
+export const SITE_AUTHOR = {
+  '@type': 'Person',
+  name: 'Itaru OTA',
+  url: SITE_URL,
+} as const;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -40,6 +40,14 @@ html,
 body {
   max-width: 100vw;
   min-height: 100%;
+}
+
+/*
+ * Only the root element clips horizontal overflow. `overflow-x` on `body`
+ * would turn it into a scroll container, which stops the sticky header from
+ * sticking to the viewport.
+ */
+html {
   overflow-x: hidden;
 }
 

--- a/src/theme/layout.ts
+++ b/src/theme/layout.ts
@@ -1,2 +1,5 @@
 /** Shared measure for the main content column across the portfolio and blog. */
 export const CONTENT_MAX_WIDTH = 600;
+
+/** Room left for the sticky header when jumping to an in-page anchor. */
+export const ANCHOR_SCROLL_MARGIN = 96;

--- a/src/theme/layout.ts
+++ b/src/theme/layout.ts
@@ -1,0 +1,2 @@
+/** Shared measure for the main content column across the portfolio and blog. */
+export const CONTENT_MAX_WIDTH = 600;


### PR DESCRIPTION
## Summary

Three related changes to the blog, following the flat direction the portfolio pages already moved to.

**Blog post page is no longer a card.** The article sat in a `Paper` with elevation; it now renders directly on the page background like the portfolio sections. The index keeps its cards.

**Content width is shared.** Blog pages used the full `md` container while the portfolio was capped at 600px. Both now use `CONTENT_MAX_WIDTH`, replacing the value hardcoded in six portfolio sections.

**The header sticks to the top.** Navigation was only reachable by scrolling back up. `overflow-x` moved to the root element only — on `body` it makes body a scroll container, which stops the header from sticking to the viewport — and the header background is now opaque since content scrolls under it.

## Markup and structured data

Picked up along the way, since they affect how the index is read by crawlers and screen readers:

- Cards are marked up as a list (`ul`/`li`) and dates render as `time` elements.
- The anchor text is now the title alone rather than the whole card, so the `h2` works as a heading. A stretched pseudo-element keeps the entire card clickable, and `:focus-within` gives the card a visible focus ring.
- The index emits `Blog` JSON-LD listing every entry; posts link back to it with `isPartOf`.
- `scroll-margin-top` on MDX headings widened to clear the sticky header on table-of-contents jumps.
- The site URL is a shared constant instead of being repeated across `sitemap.ts`, `robots.ts`, and the post page.

## Testing

- `npm run build`, `npm run typecheck`, `npm run lint:biome`
- Checked the home page, the blog index, and a post in `npm run dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)