### PR TITLE
Fix horizontal overflow from long inline code on mobile

### DIFF
--- a/src/components/blog/MDXComponents.tsx
+++ b/src/components/blog/MDXComponents.tsx
@@ -158,7 +158,11 @@ export const mdxComponents: MDXComponents = {
     </Typography>
   ),
   p: ({ children }) => (
-    <Typography variant="body1" paragraph sx={{ lineHeight: 1.8 }}>
+    <Typography
+      variant="body1"
+      paragraph
+      sx={{ lineHeight: 1.8, overflowWrap: 'anywhere' }}
+    >
       {children}
     </Typography>
   ),
@@ -190,7 +194,7 @@ export const mdxComponents: MDXComponents = {
     <Typography
       component="li"
       variant="body1"
-      sx={{ mb: 0.5, lineHeight: 1.8 }}
+      sx={{ mb: 0.5, lineHeight: 1.8, overflowWrap: 'anywhere' }}
     >
       {children}
     </Typography>
@@ -227,6 +231,10 @@ export const mdxComponents: MDXComponents = {
             fontFamily: 'Menlo, Monaco, "Courier New", monospace',
             fontSize: '0.9em',
             color: 'secondary.main',
+            // Identifiers like `aws_service_discovery_private_dns_namespace`
+            // have no space or hyphen to break on, so the default
+            // `overflow-wrap: normal` lets them run past the content column.
+            overflowWrap: 'anywhere',
           }}
         >
           {children}


### PR DESCRIPTION
## Problem

Two blog posts scrolled horizontally on phones. Measuring every blog page in a headless browser at a 375px viewport narrowed it to three inline code spans:

| Source | Content | Rendered width |
| --- | --- | --- |
| `content/blog/20260106_aws-ecs-beginner.mdx:343` | `service_connect_configuration.service.port_name` | 437px |
| `content/blog/20260106_aws-ecs-beginner.mdx:430` | `aws_service_discovery_private_dns_namespace` | 400px |
| `content/blog/20260131_aws-how-to-use-terraformer.mdx:144` | `generated/aws/<service>/terraform.tfstate` | 382px |

The content column is 343px at that viewport, so each of these ran past it and pushed document scroll width to 458px on the ECS post and 398px on the Terraformer post.

## Cause

None of these identifiers contain a space or a hyphen. CSS only offers a line break at those characters under the default `overflow-wrap: normal` — `_`, `.` and `/` are not break opportunities — so the line breaker had nothing to work with and each token rendered as one unbreakable word wider than its parent.

`html { overflow-x: hidden }` in `src/styles/globals.css` hides this in Chrome, where the text is clipped rather than scrollable (`window.scrollTo(500, 0)` leaves `scrollX` at 0). iOS Safari still allows the visual viewport to pan, which is where the horizontal scroll was visible.

## Change

`overflow-wrap: anywhere` on the inline `code` component, plus on `p` and `li` so a long bare URL in prose cannot reintroduce the same problem later. `anywhere` still prefers ordinary break opportunities where they exist, so short inline code such as `portMappings[].name` renders exactly as before.

Code blocks and tables are untouched — `CodeBlock` and `TableContainer` already scroll inside their own containers, which is intended.

## Verification

- Rebuilt and re-measured all 12 blog pages at 375px and 320px. Document scroll width now equals the viewport on every page, and zero overflowing elements remain outside a scroll container (previously 3 across 2 pages).
- Screenshot at 375px confirms the long identifier wraps onto two lines within the column while short inline code is unchanged.
- `npm run build` and `biome check` both pass.

One unrelated note: the KubeCon post reports a 322px scroll width at a 320px viewport. That predates this change, flags no overflowing element, and appears to be a 2px rounding artifact inside a scroll container. Left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkCm6kmRfFtuWCQFiUJuoo)_